### PR TITLE
Change very-near? to a function

### DIFF
--- a/datasets/src/cortex_datasets/math.clj
+++ b/datasets/src/cortex_datasets/math.clj
@@ -3,9 +3,11 @@
 
 (def epsilon 1e-6)
 
-(defmacro very-near?
-  [x y]
-  `(< (Math/abs (- ~x ~y)) epsilon))
+(defn very-near-epsilon?
+  [epsilon x y]
+  (< (Math/abs (- x y)) epsilon))
+  
+(def very-near? (partial very-near-epsilon? epsilon))
 
 (defn matrix-col-totals
   [data]


### PR DESCRIPTION
Following the first rule of Macro-club (Don't use macros !) I turned very-near? to a partial function application. 
No need for a macro to capture the global epsilon definition.