### PR TITLE
Non nio compute

### DIFF
--- a/compute/src/think/compute/array_view_math.clj
+++ b/compute/src/think/compute/array_view_math.clj
@@ -1,0 +1,287 @@
+(ns think.compute.array-view-math
+  (:require [think.compute.datatype :as dtype]
+            [think.compute.math-util :refer :all]
+            [clojure.core.matrix.macros :refer [c-for]]
+            [think.compute.datatype :refer [v-aget-rem v-aset-rem v-aget v-aset] :as dtype]
+            [think.resource.core :as resource])
+  (:import [com.github.fommil.netlib BLAS]
+           [java.util Random]
+           [think.compute DoubleArrayView FloatArrayView ArrayView
+            LongArrayView IntArrayView ShortArrayView ByteArrayView]))
+
+
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+
+(defprotocol PCPUMathImpl
+  (gemm [A a-colstride
+             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
+             B b-colstride
+             beta C c-colstride])
+  (sum [x alpha beta y result])
+  (gemv [A a-colstride trans-a a-row-count a-col-count alpha x inc-x beta y inc-y])
+  (mul-rows [A a-colstride a-row-count a-col-count X inc-x C c-colstride])
+  (elem-mul [a inc-a alpha b inc-b res inc-res])
+  ;;Create a scale vector with either 1.0 in the row if the row-len is < the
+  ;;l2 constraint or (/ l2-max-constraint row-len) otherwise.
+  (l2-constraint-scale [a inc-a l2-max-constraint])
+  (generate-rands [rand-buffer distribution]))
+
+
+(defmacro sum-impl
+  [x alpha beta y result cast-fn]
+  `(let [alpha# (~cast-fn ~alpha)
+         beta# (~cast-fn ~beta)
+         y-view# (ArrayView/toView ~y)
+         x-view# (ArrayView/toView ~x)
+         res-view# (ArrayView/toView ~result)
+         num-elems# (Math/max (.length x-view#) (.length y-view#))]
+     (c-for [idx# 0 (< idx# num-elems#) (inc idx#)]
+            (v-aset-rem res-view# idx#
+                  (+ (* alpha# (v-aget-rem x-view# idx#))
+                     (* beta# (v-aget-rem y-view# idx#)))))))
+
+
+(defmacro mul-rows-impl
+  [A a-colstride a-row-count a-col-count x inc-x C c-colstride]
+  `(let [~a-colstride (long ~a-colstride)
+         ~a-row-count (long ~a-row-count)
+         ~a-col-count (long ~a-col-count)
+         ~inc-x (long ~inc-x)
+         ~c-colstride (long ~c-colstride)
+         A# (ArrayView/toView ~A)
+         x# (ArrayView/toView ~x)
+         C# (ArrayView/toView ~C)]
+     (c-for
+      [row# 0 (< row# ~a-row-count) (inc row#)]
+      (let [a-row-offset# (* ~a-colstride row#)
+            x-offset# (* row# ~inc-x)
+            c-row-offset# (* ~c-colstride row#)
+            x-val# (v-aget x# x-offset#)]
+        (c-for
+         [col# 0 (< col# ~a-col-count) (inc col#)]
+         (v-aset C# (+ c-row-offset# col#)
+               (* x-val# (v-aget A# (+ a-row-offset# col#)))))))))
+
+(defmacro elem-mul-impl
+  [a inc-a alpha b inc-b res inc-res cast-fn]
+  `(let [alpha# (~cast-fn ~alpha)
+         a# (ArrayView/toView ~a)
+         inc-a# (long ~inc-a)
+         b# (ArrayView/toView ~b)
+         inc-b# (long ~inc-b)
+         res# (ArrayView/toView ~res)
+         inc-res# (long ~inc-res)
+         elem-count# (quot (.length a#) inc-a#)]
+     (c-for [idx# 0 (< idx# elem-count#) (inc idx#)]
+            (v-aset res# (* inc-res# idx#)
+                    (* (* alpha# (v-aget a# (* inc-a# idx#)))
+                       (v-aget b# (* inc-b# idx#)))))))
+
+(defmacro l2-constraint-scale-impl
+  [a inc-a l2-max-constraint cast-fn]
+  `(let [a# (ArrayView/toView ~a)
+         inc-a# (long ~inc-a)
+         a-elem-count# (quot (.length a#) inc-a#)
+         l2-max-constraint# (~cast-fn ~l2-max-constraint)]
+     (c-for [idx# 0 (< idx# a-elem-count#) (inc idx#)]
+            (let [a-offset# (* idx# inc-a#)
+                  row-len# (Math/sqrt (v-aget a# a-offset#))]
+              (if (< row-len# l2-max-constraint#)
+                (v-aset a# a-offset# 1.0)
+                (v-aset a# a-offset# (/ l2-max-constraint# row-len#)))))))
+
+(extend-protocol PCPUMathImpl
+  DoubleArrayView
+  (gemm [^DoubleArrayView A a-colstride
+             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
+             ^DoubleArrayView B b-colstride
+             beta ^DoubleArrayView C c-colstride]
+    (col->row-gemm (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
+                        alpha ^DoubleArrayView A a-rowstride
+                        ^DoubleArrayView B b-rowstride
+                        beta ^DoubleArrayView C c-rowstride]
+                     (let [trans-a? (bool->blas-trans trans-a?)
+                           trans-b? (bool->blas-trans trans-b?)
+                           M (long a-row-count)
+                           N (long b-col-count)
+                           K (long a-col-count)
+                           alpha (double alpha)
+                           beta (double beta)
+                           A-offset (.offset A)
+                           B-offset (.offset B)
+                           C-offset (.offset C)
+                           A (.data A)
+                           B (.data B)
+                           C (.data C)]
+                       (.dgemm (BLAS/getInstance) trans-a? trans-b?
+                               M N K
+                               alpha A A-offset a-rowstride
+                               B B-offset b-rowstride
+                               beta C C-offset c-rowstride)))
+                   trans-a? trans-b? a-row-count a-col-count b-col-count
+                   alpha A a-colstride
+                   B b-colstride
+                   beta C c-colstride))
+  (sum [^DoubleArrayView x alpha beta
+            ^DoubleArrayView y
+            ^DoubleArrayView result]
+    (sum-impl x alpha beta y result double))
+  (gemv [^DoubleArrayView A a-colstride trans-a? a-row-count a-col-count
+             alpha ^DoubleArrayView x inc-x
+             beta ^DoubleArrayView y inc-y]
+    (col->row-gemv (fn [trans-a? a-row-count a-col-count
+                        alpha ^DoubleArrayView A a-colstride
+                        ^DoubleArrayView x inc-x
+                        beta ^DoubleArrayView y inc-y]
+                     (let [a-colstride (long a-colstride)
+                           a-row-count (long a-row-count)
+                           a-col-count (long a-col-count)
+                           A-offset (.offset A)
+                           x-offset (.offset x)
+                           y-offset (.offset y)
+                           A (.data A)
+                           x (.data x)
+                           y (.data y)
+                           alpha (double alpha)
+                           inc-x (long inc-x)
+                           beta (double beta)
+                           inc-y (long inc-y)]
+                       (.dgemv (BLAS/getInstance) (bool->blas-trans trans-a?)
+                               a-row-count a-col-count
+                               alpha A A-offset a-colstride
+                               x x-offset inc-x
+                               beta y y-offset inc-y)))
+                   trans-a? a-row-count a-col-count
+                   alpha A a-colstride
+                   x inc-x
+                   beta y inc-y))
+  (mul-rows [^DoubleArrayView A a-colstride a-row-count a-col-count
+                 ^DoubleArrayView x inc-x ^DoubleArrayView C c-colstride]
+    (mul-rows-impl A a-colstride a-row-count a-col-count x inc-x C c-colstride))
+  (elem-mul [^DoubleArrayView a inc-a alpha ^DoubleArrayView b inc-b
+                 ^DoubleArrayView res inc-res]
+    (elem-mul-impl a inc-a alpha b inc-b res inc-res double))
+  (l2-constraint-scale [^DoubleArrayView a inc-a l2-max-constraint]
+    (l2-constraint-scale-impl a inc-a l2-max-constraint double))
+  (generate-rands [^DoubleArrayView rand-buffer distribution elem-count]
+    (throw (Exception. "Random generation operates on float buffers for CUDA compatibility")))
+
+  FloatArrayView
+  (gemm [^FloatArrayView A a-colstride
+             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
+             ^FloatArrayView B b-colstride
+             beta ^FloatArrayView C c-colstride]
+    (col->row-gemm (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
+                        alpha ^FloatArrayView A a-rowstride
+                        ^FloatArrayView B b-rowstride
+                        beta ^FloatArrayView C c-rowstride]
+                     (let [trans-a? (bool->blas-trans trans-a?)
+                           trans-b? (bool->blas-trans trans-b?)
+                           M (long a-row-count)
+                           N (long b-col-count)
+                           K (long a-col-count)
+                           alpha (float alpha)
+                           beta (float beta)
+                           A-offset (.offset A)
+                           B-offset (.offset B)
+                           C-offset (.offset C)
+                           A (.data A)
+                           B (.data B)
+                           C (.data C)]
+                       (.sgemm (BLAS/getInstance) trans-a? trans-b?
+                               M N K
+                               alpha A A-offset a-rowstride
+                               B B-offset b-rowstride
+                               beta C C-offset c-rowstride)))
+                   trans-a? trans-b? a-row-count a-col-count b-col-count
+                   alpha A a-colstride
+                   B b-colstride
+                   beta C c-colstride))
+  (sum [^FloatArrayView x alpha beta
+            ^FloatArrayView y
+            ^FloatArrayView result]
+    (sum-impl x alpha beta y result float))
+  (gemv [^FloatArrayView A a-colstride trans-a? a-row-count a-col-count
+             alpha ^FloatArrayView x inc-x
+             beta ^FloatArrayView y inc-y]
+    (col->row-gemv (fn [trans-a? a-row-count a-col-count
+                        alpha ^FloatArrayView A a-colstride
+                        ^FloatArrayView x inc-x
+                        beta ^FloatArrayView y inc-y]
+                     (let [a-colstride (long a-colstride)
+                           a-row-count (long a-row-count)
+                           a-col-count (long a-col-count)
+                           A-offset (.offset A)
+                           x-offset (.offset x)
+                           y-offset (.offset y)
+                           A (.data A)
+                           x (.data x)
+                           y (.data y)
+                           alpha (float alpha)
+                           inc-x (long inc-x)
+                           beta (float beta)
+                           inc-y (long inc-y)]
+                       (.sgemv (BLAS/getInstance) (bool->blas-trans trans-a?)
+                               a-row-count a-col-count
+                               alpha A A-offset a-colstride
+                               x x-offset inc-x
+                               beta y y-offset inc-y)))
+                   trans-a? a-row-count a-col-count
+                   alpha A a-colstride
+                   x inc-x
+                   beta y inc-y))
+  (mul-rows [^FloatArrayView A a-colstride a-row-count a-col-count
+                 ^FloatArrayView x inc-x ^FloatArrayView C c-colstride]
+    (mul-rows-impl A a-colstride a-row-count a-col-count x inc-x C c-colstride))
+  (elem-mul [^FloatArrayView a inc-a alpha ^FloatArrayView b inc-b
+                 ^FloatArrayView res inc-res]
+    (elem-mul-impl a inc-a alpha b inc-b res inc-res float))
+  (l2-constraint-scale [^FloatArrayView a inc-a l2-max-constraint]
+    (l2-constraint-scale-impl a inc-a l2-max-constraint float))
+  (generate-rands [^FloatArrayView rand-buffer distribution]
+    (let [rand-view (ArrayView/toView rand-buffer)
+          rand-gen (Random.)
+          elem-count (.length rand-view)]
+      (cond
+        (= (:type distribution) :gaussian)
+        (let [mean (float (:mean distribution))
+              variance (float (:variance distribution))
+              sum-var (float-array 2)]
+          (c-for [idx 0 (< idx elem-count) (inc idx)]
+                 (let [next-rand (.nextGaussian rand-gen)]
+                   (v-aset rand-view idx next-rand)
+                   (aset sum-var 0 (+ (aget sum-var 0) next-rand))
+                   (aset sum-var 1 (+ (aget sum-var 1)
+                                      (float (Math/abs next-rand))))))
+          (let [actual-variance (/ (aget sum-var 1) elem-count)
+                variance-fix (float (Math/sqrt (if (> actual-variance 0.0)
+                                                 (/ variance actual-variance)
+                                                 actual-variance)))
+                actual-mean (/ (aget sum-var 0) elem-count)
+                adjusted-mean (* actual-mean variance-fix)
+                mean-fix (- mean adjusted-mean)]
+            (c-for [idx 0 (< idx elem-count) (inc idx)]
+                   (v-aset rand-view idx (+ (* variance-fix (v-aget rand-view idx))
+                                            mean-fix)))))
+        (= (:type distribution) :flat)
+        (c-for [idx 0 (< idx elem-count) (inc idx)]
+               (v-aset rand-view idx (float (.nextFloat rand-gen))))
+        :else
+        (throw (Exception. (str "Unrecognized distribution: " distribution)))))))
+
+
+(extend-protocol resource/PResource
+  ByteArrayView
+  (release-resource [item])
+  ShortArrayView
+  (release-resource [item])
+  IntArrayView
+  (release-resource [item])
+  LongArrayView
+  (release-resource [item])
+  FloatArrayView
+  (release-resource [item])
+  DoubleArrayView
+  (release-resource [item]))

--- a/compute/src/think/compute/cpu_driver.clj
+++ b/compute/src/think/compute/cpu_driver.clj
@@ -5,7 +5,8 @@
             [clojure.core.async :as async]
             [think.resource.core :as resource]
             [clojure.core.matrix.macros :refer [c-for]]
-            [clojure.core.matrix :as m])
+            [clojure.core.matrix :as m]
+            [think.compute.array-view-math :as avm])
   (:import [java.nio ByteBuffer IntBuffer ShortBuffer LongBuffer
             FloatBuffer DoubleBuffer Buffer]
            [com.github.fommil.netlib BLAS]
@@ -127,309 +128,16 @@ primitives will just hang with this stream."
     (create-cpu-stream (:error-atom impl)))
   (allocate-host-buffer [impl elem-count elem-type]
     (check-stream-error impl)
-    (dtype/make-buffer elem-type elem-count))
+    (dtype/make-view elem-type elem-count))
   (allocate-device-buffer [impl elem-count elem-type]
     (check-stream-error impl)
-    (dtype/make-buffer elem-type elem-count))
+    (dtype/make-view elem-type elem-count))
   (allocate-rand-buffer [impl elem-count]
     (check-stream-error impl)
-    (dtype/make-buffer :float elem-count))
+    (dtype/make-view :float elem-count))
   (sub-buffer-impl [impl buffer offset length]
-    (dtype/offset-buffer buffer offset length)))
+    (dtype/->view buffer offset length)))
 
-(defprotocol PNIOBufferMath
-  (nio-gemm [A a-colstride
-             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
-             B b-colstride
-             beta C c-colstride])
-  (nio-sum [x alpha beta y result])
-  (nio-gemv [A a-colstride trans-a a-row-count a-col-count alpha x inc-x beta y inc-y])
-  (nio-mul-rows [A a-colstride a-row-count a-col-count X inc-x C c-colstride])
-  (nio-elem-mul [a inc-a alpha b inc-b res inc-res])
-  ;;Create a scale vector with either 1.0 in the row if the row-len is < the
-  ;;l2 constraint or (/ l2-max-constraint row-len) otherwise.
-  (nio-l2-constraint-scale [a inc-a l2-max-constraint])
-  (nio-generate-rands [rand-buffer distribution]))
-
-
-;;A (a x b)
-;;B (b x c)
-;;C (a x c)
-;; (a x b)(b x c) = (a x c)
-;;transposed is:
-;; A (b x a)
-;; B (c x b)
-;; C (c x a)
-;; (c x b)(b x a) = (c x a)
-;; a = a-row-count
-;; b = a-col-count = b-row-count
-;; c = b-col-count
-(defn col->row-gemm
-  "Perform a column major gemm using a library that is row-major."
-  [blas-fn trans-a? trans-b? a-row-count a-col-count b-col-count
-   alpha A a-colstride
-   B b-colstride
-   beta C c-colstride]
-  (blas-fn trans-b? trans-a?
-           b-col-count a-col-count a-row-count
-           alpha B b-colstride
-           A a-colstride
-           beta C c-colstride))
-
-
-(defn bool->blas-trans
-  ^String [trans?]
-  (if trans? "t" "n"))
-
-
-(defn col->row-gemv
-  "Perform a column-major gemv using a library that is row-major."
-  [blas-fn trans-a a-row-count a-col-count alpha a a-colstride x inc-x beta y inc-y]
-  (blas-fn (not trans-a) a-col-count a-row-count
-           alpha a a-colstride
-           x inc-x
-           beta y inc-y))
-
-(defmacro nio-sum-impl
-  [x alpha beta y result cast-fn]
-  `(let [alpha# (~cast-fn ~alpha)
-         beta# (~cast-fn ~beta)
-         y-view# (ArrayView/toView ~y)
-         x-view# (ArrayView/toView ~x)
-         res-view# (ArrayView/toView ~result)
-         num-elems# (Math/max (.length x-view#) (.length y-view#))]
-     (c-for [idx# 0 (< idx# num-elems#) (inc idx#)]
-            (v-aset-rem res-view# idx#
-                  (+ (* alpha# (v-aget-rem x-view# idx#))
-                     (* beta# (v-aget-rem y-view# idx#)))))))
-
-(defmacro nio-mul-rows-impl
-  [A a-colstride a-row-count a-col-count x inc-x C c-colstride]
-  `(let [~a-colstride (long ~a-colstride)
-         ~a-row-count (long ~a-row-count)
-         ~a-col-count (long ~a-col-count)
-         ~inc-x (long ~inc-x)
-         ~c-colstride (long ~c-colstride)
-         A# (ArrayView/toView ~A)
-         x# (ArrayView/toView ~x)
-         C# (ArrayView/toView ~C)]
-     (c-for
-      [row# 0 (< row# ~a-row-count) (inc row#)]
-      (let [a-row-offset# (* ~a-colstride row#)
-            x-offset# (* row# ~inc-x)
-            c-row-offset# (* ~c-colstride row#)
-            x-val# (v-aget x# x-offset#)]
-        (c-for
-         [col# 0 (< col# ~a-col-count) (inc col#)]
-         (v-aset C# (+ c-row-offset# col#)
-               (* x-val# (v-aget A# (+ a-row-offset# col#)))))))))
-
-(defmacro nio-elem-mul-impl
-  [a inc-a alpha b inc-b res inc-res cast-fn]
-  `(let [alpha# (~cast-fn ~alpha)
-         a# (ArrayView/toView ~a)
-         inc-a# (long ~inc-a)
-         b# (ArrayView/toView ~b)
-         inc-b# (long ~inc-b)
-         res# (ArrayView/toView ~res)
-         inc-res# (long ~inc-res)
-         elem-count# (quot (.length a#) inc-a#)]
-     (c-for [idx# 0 (< idx# elem-count#) (inc idx#)]
-            (v-aset res# (* inc-res# idx#)
-                    (* (* alpha# (v-aget a# (* inc-a# idx#)))
-                       (v-aget b# (* inc-b# idx#)))))))
-
-(defmacro nio-l2-constraint-scale-impl
-  [a inc-a l2-max-constraint cast-fn]
-  `(let [a# (ArrayView/toView ~a)
-         inc-a# (long ~inc-a)
-         a-elem-count# (quot (.length a#) inc-a#)
-         l2-max-constraint# (~cast-fn ~l2-max-constraint)]
-     (c-for [idx# 0 (< idx# a-elem-count#) (inc idx#)]
-            (let [a-offset# (* idx# inc-a#)
-                  row-len# (Math/sqrt (v-aget a# a-offset#))]
-              (if (< row-len# l2-max-constraint#)
-                (v-aset a# a-offset# 1.0)
-                (v-aset a# a-offset# (/ l2-max-constraint# row-len#)))))))
-
-(extend-protocol PNIOBufferMath
-  DoubleBuffer
-  (nio-gemm [^DoubleBuffer A a-colstride
-             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
-             ^DoubleBuffer B b-colstride
-             beta ^DoubleBuffer C c-colstride]
-    (col->row-gemm (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
-                        alpha ^DoubleBuffer A a-rowstride
-                        ^DoubleBuffer B b-rowstride
-                        beta ^DoubleBuffer C c-rowstride]
-                     (let [trans-a? (bool->blas-trans trans-a?)
-                           trans-b? (bool->blas-trans trans-b?)
-                           M (long a-row-count)
-                           N (long b-col-count)
-                           K (long a-col-count)
-                           alpha (double alpha)
-                           beta (double beta)
-                           A-offset (.arrayOffset A)
-                           B-offset (.arrayOffset B)
-                           C-offset (.arrayOffset C)
-                           A (.array A)
-                           B (.array B)
-                           C (.array C)]
-                       (.dgemm (BLAS/getInstance) trans-a? trans-b?
-                               M N K
-                               alpha A A-offset a-rowstride
-                               B B-offset b-rowstride
-                               beta C C-offset c-rowstride)))
-                   trans-a? trans-b? a-row-count a-col-count b-col-count
-                   alpha A a-colstride
-                   B b-colstride
-                   beta C c-colstride))
-  (nio-sum [^DoubleBuffer x alpha beta
-            ^DoubleBuffer y
-            ^DoubleBuffer result]
-    (nio-sum-impl x alpha beta y result double))
-  (nio-gemv [^DoubleBuffer A a-colstride trans-a? a-row-count a-col-count
-             alpha ^DoubleBuffer x inc-x
-             beta ^DoubleBuffer y inc-y]
-    (col->row-gemv (fn [trans-a? a-row-count a-col-count
-                        alpha ^DoubleBuffer A a-colstride
-                        ^DoubleBuffer x inc-x
-                        beta ^DoubleBuffer y inc-y]
-                     (let [a-colstride (long a-colstride)
-                           a-row-count (long a-row-count)
-                           a-col-count (long a-col-count)
-                           A-offset (.arrayOffset A)
-                           x-offset (.arrayOffset x)
-                           y-offset (.arrayOffset y)
-                           A (.array A)
-                           x (.array x)
-                           y (.array y)
-                           alpha (double alpha)
-                           inc-x (long inc-x)
-                           beta (double beta)
-                           inc-y (long inc-y)]
-                       (.dgemv (BLAS/getInstance) (bool->blas-trans trans-a?)
-                               a-row-count a-col-count
-                               alpha A A-offset a-colstride
-                               x x-offset inc-x
-                               beta y y-offset inc-y)))
-                   trans-a? a-row-count a-col-count
-                   alpha A a-colstride
-                   x inc-x
-                   beta y inc-y))
-  (nio-mul-rows [^DoubleBuffer A a-colstride a-row-count a-col-count
-                 ^DoubleBuffer x inc-x ^DoubleBuffer C c-colstride]
-    (nio-mul-rows-impl A a-colstride a-row-count a-col-count x inc-x C c-colstride))
-  (nio-elem-mul [^DoubleBuffer a inc-a alpha ^DoubleBuffer b inc-b
-                 ^DoubleBuffer res inc-res]
-    (nio-elem-mul-impl a inc-a alpha b inc-b res inc-res double))
-  (nio-l2-constraint-scale [^DoubleBuffer a inc-a l2-max-constraint]
-    (nio-l2-constraint-scale-impl a inc-a l2-max-constraint double))
-  (nio-generate-rands [^DoubleBuffer rand-buffer distribution elem-count]
-    (throw (Exception. "Random generation operates on float buffers for CUDA compatibility")))
-
-  FloatBuffer
-  (nio-gemm [^FloatBuffer A a-colstride
-             trans-a? trans-b? a-row-count a-col-count b-col-count alpha
-             ^FloatBuffer B b-colstride
-             beta ^FloatBuffer C c-colstride]
-    (col->row-gemm (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
-                        alpha ^FloatBuffer A a-rowstride
-                        ^FloatBuffer B b-rowstride
-                        beta ^FloatBuffer C c-rowstride]
-                     (let [trans-a? (bool->blas-trans trans-a?)
-                           trans-b? (bool->blas-trans trans-b?)
-                           M (long a-row-count)
-                           N (long b-col-count)
-                           K (long a-col-count)
-                           alpha (float alpha)
-                           beta (float beta)
-                           A-offset (.arrayOffset A)
-                           B-offset (.arrayOffset B)
-                           C-offset (.arrayOffset C)
-                           A (.array A)
-                           B (.array B)
-                           C (.array C)]
-                       (.sgemm (BLAS/getInstance) trans-a? trans-b?
-                               M N K
-                               alpha A A-offset a-rowstride
-                               B B-offset b-rowstride
-                               beta C C-offset c-rowstride)))
-                   trans-a? trans-b? a-row-count a-col-count b-col-count
-                   alpha A a-colstride
-                   B b-colstride
-                   beta C c-colstride))
-  (nio-sum [^FloatBuffer x alpha beta
-            ^FloatBuffer y
-            ^FloatBuffer result]
-    (nio-sum-impl x alpha beta y result float))
-  (nio-gemv [^FloatBuffer A a-colstride trans-a? a-row-count a-col-count
-             alpha ^FloatBuffer x inc-x
-             beta ^FloatBuffer y inc-y]
-    (col->row-gemv (fn [trans-a? a-row-count a-col-count
-                        alpha ^FloatBuffer A a-colstride
-                        ^FloatBuffer x inc-x
-                        beta ^FloatBuffer y inc-y]
-                     (let [a-colstride (long a-colstride)
-                           a-row-count (long a-row-count)
-                           a-col-count (long a-col-count)
-                           A-offset (.arrayOffset A)
-                           x-offset (.arrayOffset x)
-                           y-offset (.arrayOffset y)
-                           A (.array A)
-                           x (.array x)
-                           y (.array y)
-                           alpha (float alpha)
-                           inc-x (long inc-x)
-                           beta (float beta)
-                           inc-y (long inc-y)]
-                       (.sgemv (BLAS/getInstance) (bool->blas-trans trans-a?)
-                               a-row-count a-col-count
-                               alpha A A-offset a-colstride
-                               x x-offset inc-x
-                               beta y y-offset inc-y)))
-                   trans-a? a-row-count a-col-count
-                   alpha A a-colstride
-                   x inc-x
-                   beta y inc-y))
-  (nio-mul-rows [^FloatBuffer A a-colstride a-row-count a-col-count
-                 ^FloatBuffer x inc-x ^FloatBuffer C c-colstride]
-    (nio-mul-rows-impl A a-colstride a-row-count a-col-count x inc-x C c-colstride))
-  (nio-elem-mul [^FloatBuffer a inc-a alpha ^FloatBuffer b inc-b
-                 ^FloatBuffer res inc-res]
-    (nio-elem-mul-impl a inc-a alpha b inc-b res inc-res float))
-  (nio-l2-constraint-scale [^FloatBuffer a inc-a l2-max-constraint]
-    (nio-l2-constraint-scale-impl a inc-a l2-max-constraint float))
-  (nio-generate-rands [^FloatBuffer rand-buffer distribution]
-    (let [rand-view (ArrayView/toView rand-buffer)
-          rand-gen (Random.)
-          elem-count (.length rand-view)]
-      (cond
-        (= (:type distribution) :gaussian)
-        (let [mean (float (:mean distribution))
-              variance (float (:variance distribution))
-              sum-var (float-array 2)]
-          (c-for [idx 0 (< idx elem-count) (inc idx)]
-                 (let [next-rand (.nextGaussian rand-gen)]
-                   (v-aset rand-view idx next-rand)
-                   (aset sum-var 0 (+ (aget sum-var 0) next-rand))
-                   (aset sum-var 1 (+ (aget sum-var 1)
-                                      (float (Math/abs next-rand))))))
-          (let [actual-variance (/ (aget sum-var 1) elem-count)
-                variance-fix (float (Math/sqrt (if (> actual-variance 0.0)
-                                                 (/ variance actual-variance)
-                                                 actual-variance)))
-                actual-mean (/ (aget sum-var 0) elem-count)
-                adjusted-mean (* actual-mean variance-fix)
-                mean-fix (- mean adjusted-mean)]
-            (c-for [idx 0 (< idx elem-count) (inc idx)]
-                   (v-aset rand-view idx (+ (* variance-fix (v-aget rand-view idx))
-                                            mean-fix)))))
-        (= (:type distribution) :flat)
-        (c-for [idx 0 (< idx elem-count) (inc idx)]
-               (v-aset rand-view idx (float (.nextFloat rand-gen))))
-        :else
-        (throw (Exception. (str "Unrecognized distribution: " distribution)))))))
 
 (extend-type CPUStream
   c-math/PMath
@@ -437,28 +145,31 @@ primitives will just hang with this stream."
               B b-colstride
               beta C c-colstride]
     (with-stream-dispatch stream
-      (nio-gemm A a-colstride
+      (avm/gemm (dtype/->view A) a-colstride
                 trans-a? trans-b? a-row-count a-col-count b-col-count alpha
-                B b-colstride
-                beta C c-colstride)))
+                (dtype/->view B) b-colstride
+                beta (dtype/->view C) c-colstride)))
   (sum-impl [stream alpha x beta y result]
     (with-stream-dispatch stream
-      (nio-sum x alpha beta y result)))
+      (avm/sum (dtype/->view x) alpha beta (dtype/->view y) (dtype/->view result))))
   (gemv-impl [stream trans-a? a-row-count a-col-count alpha A a-colstride x inc-x beta y inc-y]
     (with-stream-dispatch stream
-      (nio-gemv A a-colstride trans-a? a-row-count a-col-count alpha x inc-x beta y inc-y)))
+      (avm/gemv (dtype/->view A) a-colstride trans-a? a-row-count a-col-count alpha
+                (dtype/->view x) inc-x beta (dtype/->view y) inc-y)))
   (mul-rows [stream a-row-count a-col-count A a-colstride x inc-x C c-colstride]
     (with-stream-dispatch stream
-      (nio-mul-rows A a-colstride a-row-count a-col-count x inc-x C c-colstride)))
+      (avm/mul-rows (dtype/->view A) a-colstride a-row-count a-col-count
+                    (dtype/->view x) inc-x (dtype/->view C) c-colstride)))
   (elem-mul [stream alpha a inc-a b inc-b res inc-res]
     (with-stream-dispatch stream
-      (nio-elem-mul a inc-a alpha b inc-b res inc-res)))
+      (avm/elem-mul (dtype/->view a) inc-a alpha (dtype/->view b) inc-b (dtype/->view res)
+                    inc-res)))
   (l2-constraint-scale [stream a inc-a l2-max-constraint]
     (with-stream-dispatch stream
-      (nio-l2-constraint-scale a inc-a l2-max-constraint)))
+      (avm/l2-constraint-scale (dtype/->view a) inc-a l2-max-constraint)))
   (generate-rands [stream rand-buffer distribution]
     (with-stream-dispatch stream
-      (nio-generate-rands rand-buffer distribution))))
+      (avm/generate-rands (dtype/->view rand-buffer) distribution))))
 
 
 (extend-type Buffer

--- a/compute/src/think/compute/datatype.clj
+++ b/compute/src/think/compute/datatype.clj
@@ -165,11 +165,18 @@ The function signature will be:
 
 
 (defn ->view
-  [item ^long offset ^long elem-count]
-  (let [item-ecount (long (m/ecount item))]
-    (when-not (>= (- item-ecount offset) elem-count)
-      (throw (Exception. "View out of range")))
-    (->view-impl item offset elem-count)))
+  ([item ^long offset ^long elem-count]
+   (let [item-ecount (long (m/ecount item))]
+     (when-not (>= (- item-ecount offset) elem-count)
+       (throw (Exception. "View out of range")))
+     (->view-impl item offset elem-count)))
+  ([item]
+   (->view item 0 (m/ecount item))))
+
+
+(defn make-view
+  [datatype item-count-or-seq]
+  (->view (make-array-of-type datatype item-count-or-seq)))
 
 
 (extend-type ByteArrayView
@@ -312,27 +319,27 @@ The function signature will be:
 
 ;;Macros to use to use the sub views as efficiently as one uses arrays.
 (defmacro v-aset
-  [sub-view item-offset value]
-  `(aset (.data ~sub-view) (+ (.offset ~sub-view) ~item-offset) ~value))
+  [array-view item-offset value]
+  `(aset (.data ~array-view) (+ (.offset ~array-view) ~item-offset) ~value))
 
 (defmacro v-aget
-  [sub-view item-offset]
-  `(aget (.data ~sub-view) (+ (.offset ~sub-view) ~item-offset)))
+  [array-view item-offset]
+  `(aget (.data ~array-view) (+ (.offset ~array-view) ~item-offset)))
 
 (defmacro v-aset-rem
-  [sub-view item-offset value]
-  `(aset (.data ~sub-view) (rem (+ (.offset ~sub-view) ~item-offset)
-                                (.length ~sub-view))
+  [array-view item-offset value]
+  `(aset (.data ~array-view) (rem (+ (.offset ~array-view) ~item-offset)
+                                (.length ~array-view))
          ~value))
 
 (defmacro v-aget-rem
-  [sub-view item-offset]
-  `(aget (.data ~sub-view) (rem (+ (.offset ~sub-view) ~item-offset)
-                                (.length ~sub-view))))
+  [array-view item-offset]
+  `(aget (.data ~array-view) (rem (+ (.offset ~array-view) ~item-offset)
+                                (.length ~array-view))))
 
 (defmacro v-alength
-  [sub-view]
-  `(.length ~sub-view))
+  [array-view]
+  `(.length ~array-view))
 
 
 (defprotocol PView

--- a/compute/src/think/compute/math_util.clj
+++ b/compute/src/think/compute/math_util.clj
@@ -1,0 +1,41 @@
+(ns think.compute.math-util)
+
+
+
+;;A (a x b)
+;;B (b x c)
+;;C (a x c)
+;; (a x b)(b x c) = (a x c)
+;;transposed is:
+;; A (b x a)
+;; B (c x b)
+;; C (c x a)
+;; (c x b)(b x a) = (c x a)
+;; a = a-row-count
+;; b = a-col-count = b-row-count
+;; c = b-col-count
+(defn col->row-gemm
+  "Perform a column major gemm using a library that is row-major."
+  [blas-fn trans-a? trans-b? a-row-count a-col-count b-col-count
+   alpha A a-colstride
+   B b-colstride
+   beta C c-colstride]
+  (blas-fn trans-b? trans-a?
+           b-col-count a-col-count a-row-count
+           alpha B b-colstride
+           A a-colstride
+           beta C c-colstride))
+
+
+(defn bool->blas-trans
+  ^String [trans?]
+  (if trans? "t" "n"))
+
+
+(defn col->row-gemv
+  "Perform a column-major gemv using a library that is row-major."
+  [blas-fn trans-a a-row-count a-col-count alpha a a-colstride x inc-x beta y inc-y]
+  (blas-fn (not trans-a) a-col-count a-row-count
+           alpha a a-colstride
+           x inc-x
+           beta y inc-y))

--- a/compute/src/think/compute/nn/cpu_backend.clj
+++ b/compute/src/think/compute/nn/cpu_backend.clj
@@ -17,7 +17,7 @@
            [cortex.nn.impl.layers.convolution ConvLayerConfig]
            [java.util Arrays]
            [java.util.concurrent ForkJoinPool Callable Future]
-           [think.compute ArrayView]))
+           [think.compute ArrayView DoubleArrayView FloatArrayView]))
 
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
@@ -35,30 +35,30 @@
    (create-cpu-backend :double)))
 
 
-(defprotocol PNIONetwork
+(defprotocol PCPUNetworkImpl
   "Implementation of various functions based on buffer datatype."
-  (nio-activation-forward [input-buf act-type output-buf])
-  (nio-activation-backward [input-buf act-type output-buf
+  (cpu-activation-forward [input-buf act-type output-buf])
+  (cpu-activation-backward [input-buf act-type output-buf
                             output-gradient input-gradient])
-  (nio-softmax-forward [input-buf output-buf n-input])
-  (nio-adadelta-step! [gradient parameters gradient-alpha param-offset
+  (cpu-softmax-forward [input-buf output-buf n-input])
+  (cpu-adadelta-step! [gradient parameters gradient-alpha param-offset
                        decay epsilon grad-accum dx-accum])
-  (nio-adam-step! [gradient parameters gradient-alpha param-offset alpha beta1 beta2 epsilon
+  (cpu-adam-step! [gradient parameters gradient-alpha param-offset alpha beta1 beta2 epsilon
                    pow_beta1_t pow_beta2_t m v])
-  (nio-planar-input->convolution! [input input-convolved conv-config])
-  (nio-convolution->planar-output! [input-convolved input-gradient conv-config])
-  (nio-fill [buffer value])
-  (nio-max-pooling-forward [input output conv-config])
-  (nio-max-pooling-backward [input output input-gradient output-gradient conv-config])
-  (nio-prepare-bernoulli-dropout [mult-buffer rand-buffer probability])
-  (nio-prepare-gaussian-dropout [mult-buffer rand-buffer])
-  (nio-bn-calc [input running-means running-variances
+  (cpu-planar-input->convolution! [input input-convolved conv-config])
+  (cpu-convolution->planar-output! [input-convolved input-gradient conv-config])
+  (cpu-fill [buffer value])
+  (cpu-max-pooling-forward [input output conv-config])
+  (cpu-max-pooling-backward [input output input-gradient output-gradient conv-config])
+  (cpu-prepare-bernoulli-dropout [mult-buffer rand-buffer probability])
+  (cpu-prepare-gaussian-dropout [mult-buffer rand-buffer])
+  (cpu-bn-calc [input running-means running-variances
                 scale bias output batch-size batch-stride])
-  (nio-update-means-variances [input
+  (cpu-update-means-variances [input
                                running-means running-variances
                                saved-means saved-variances
                                batch-size batch-stride ave-factor epsilon])
-  (nio-bn-backward [input saved-means saved-variances scale bias output
+  (cpu-bn-backward [input saved-means saved-variances scale bias output
                     scale-gradient bias-gradient input-gradient
                     output-gradient batch-size batch-stride]))
 
@@ -107,7 +107,7 @@
                                   ~@body)))))
 
 
-(defmacro nio-act-forward-impl
+(defmacro cpu-act-forward-impl
   [act-type input output cast-fn]
   `(let [src# (ArrayView/toView ~input)
          dest# (ArrayView/toView ~output)
@@ -129,7 +129,7 @@
               (v-aset dest# idx#
                     (Math/tanh (v-aget src# idx#)))))))
 
-(defmacro nio-act-backward-impl
+(defmacro cpu-act-backward-impl
   [act-type input output output-gradient input-gradient cast-fn]
   `(let [src# (ArrayView/toView ~input)
          dest# (ArrayView/toView ~output)
@@ -182,7 +182,7 @@
        sum-val#)))
 
 
-(defmacro nio-softmax-forward-impl
+(defmacro cpu-softmax-forward-impl
   [n-input input-buf output-buf cast-fn]
   `(let [~n-input (long ~n-input)
          src# (ArrayView/toView ~input-buf)
@@ -202,7 +202,7 @@
                                   sum-val#))))))))
 
 
-(defmacro nio-planar-input->convolution!-impl
+(defmacro cpu-planar-input->convolution!-impl
   [input output config cast-fn]
   `(let [input-ary# (ArrayView/toView ~input)
          output-ary# (ArrayView/toView ~output)]
@@ -216,7 +216,7 @@
          (v-aset output-ary# ~'output-conv-addr input-val#))))))
 
 
-(defmacro nio-convolution->planar-output!-impl
+(defmacro cpu-convolution->planar-output!-impl
   "Sum the convolution up to the planar input."
   [conv-input-gradient input-gradient config cast-fn]
   ;;I am using input to mean upstream or in this case destination so that
@@ -234,7 +234,7 @@
                input-val# (v-aget input-ary# ~'output-conv-addr)]
            (v-aset output-ary# ~'input-addr (+ input-val# output-val#))))))))
 
-(defmacro nio-max-pooling-forward-impl
+(defmacro cpu-max-pooling-forward-impl
   [input output config cast-fn]
   `(let [input-ary# (ArrayView/toView ~input)
          output-ary# (ArrayView/toView ~output)]
@@ -254,7 +254,7 @@
            (v-aset output-ary# output-addr# input-val#)))))))
 
 
-(defmacro nio-max-pooling-backward-impl
+(defmacro cpu-max-pooling-backward-impl
   [input output input-gradient output-gradient config cast-fn]
   `(let [input-ary# (ArrayView/toView ~input)
          output-ary# (ArrayView/toView ~output)
@@ -277,7 +277,7 @@
                  (+ (v-aget input-gradient-ary# input-addr#)
                     (v-aget output-gradient-ary# output-addr#)))))))))
 
-(defmacro nio-prepare-bernoulli-impl
+(defmacro cpu-prepare-bernoulli-impl
   [mult-buffer rand-buffer probability cast-fn]
   `(let [probability# (~cast-fn ~probability)
          scale-val# (~cast-fn (/ 1.0 probability#))
@@ -292,7 +292,7 @@
                                 scale-val#))))))
 
 
-(defmacro nio-prepare-gaussian-impl
+(defmacro cpu-prepare-gaussian-impl
   [mult-buffer rand-buffer cast-fn]
   `(let [mult-ary# (ArrayView/toView ~mult-buffer)
          elem-count# (.length mult-ary#)
@@ -302,7 +302,7 @@
                     (~cast-fn (v-aget rand-ary# idx#))))))
 
 
-(defmacro nio-bn-calc-impl
+(defmacro cpu-bn-calc-impl
   [input means variances scale bias output batch-size batch-stride cast-fn]
   `(let [input-ary# (ArrayView/toView ~input)
          means-ary# (ArrayView/toView ~means)
@@ -342,7 +342,7 @@ in order to avoid adding a small number to 0."
             (recur (+ sum-var# ~stmt) (inc ~idx-var))
             sum-var#)))))
 
-(defmacro nio-update-means-variances-impl
+(defmacro cpu-update-means-variances-impl
   [input running-means running-variances
    saved-means saved-variances
    batch-size batch-stride ave-factor epsilon cast-fn]
@@ -390,7 +390,7 @@ in order to avoid adding a small number to 0."
                                                            var-batch-size#))
                                               ave-factor#)))))))
 
-(defmacro nio-bn-backward-impl [input means variances scale bias output
+(defmacro cpu-bn-backward-impl [input means variances scale bias output
                                 scale-gradient bias-gradient input-gradient
                                 output-gradient batch-size batch-stride cast-fn]
   `(let [batch-size# (long ~batch-size)
@@ -482,150 +482,156 @@ in order to avoid adding a small number to 0."
                      (~cast-fn (+ (+ sum-part-1# sum-part-3#) sum-part-2#))))))))))
 
 
-(extend-type DoubleBuffer
-  PNIONetwork
-  (nio-activation-forward [input-buf act-type ^DoubleBuffer output-buf]
-    (nio-act-forward-impl act-type input-buf output-buf double))
-  (nio-activation-backward [input act-type ^DoubleBuffer output
-                            ^DoubleBuffer output-gradient
-                            ^DoubleBuffer input-gradient]
-    (nio-act-backward-impl act-type input output output-gradient input-gradient double))
-  (nio-softmax-forward [input-buf ^DoubleBuffer output-buf ^long n-input]
-    (nio-softmax-forward-impl n-input input-buf output-buf double))
-  (nio-adadelta-step! [gradient ^DoubleBuffer parameters gradient-alpha
-                       param-offset decay epsilon ^DoubleBuffer grad-accum
-                       ^DoubleBuffer dx-accum]
-    (AdadeltaOptimiser/step_d (double gradient-alpha) (.array gradient) (.array parameters)
+(extend-type DoubleArrayView
+  PCPUNetworkImpl
+  (cpu-activation-forward [input-buf act-type ^DoubleArrayView output-buf]
+    (cpu-act-forward-impl act-type input-buf output-buf double))
+  (cpu-activation-backward [input act-type ^DoubleArrayView output
+                            ^DoubleArrayView output-gradient
+                            ^DoubleArrayView input-gradient]
+    (cpu-act-backward-impl act-type input output output-gradient input-gradient double))
+  (cpu-softmax-forward [input-buf ^DoubleArrayView output-buf ^long n-input]
+    (cpu-softmax-forward-impl n-input input-buf output-buf double))
+  (cpu-adadelta-step! [gradient ^DoubleArrayView parameters gradient-alpha
+                       param-offset decay epsilon ^DoubleArrayView grad-accum
+                       ^DoubleArrayView dx-accum]
+    (AdadeltaOptimiser/step_d (double gradient-alpha) (.data gradient) (.data parameters)
                               (int param-offset) (double decay) (double epsilon)
-                              (.array grad-accum) (.array dx-accum)))
-  (nio-adam-step! [gradient ^DoubleBuffer parameters gradient-alpha param-offset
+                              (.data grad-accum) (.data dx-accum)))
+  (cpu-adam-step! [gradient ^DoubleArrayView parameters gradient-alpha param-offset
                    alpha beta1 beta2 epsilon pow-beta1-t pow-beta2-t
-                   ^DoubleBuffer m ^DoubleBuffer v]
-    (AdamOptimiser/step_d (double gradient-alpha) (.array gradient) (.array parameters)
+                   ^DoubleArrayView m ^DoubleArrayView v]
+    (AdamOptimiser/step_d (double gradient-alpha) (.data gradient) (.data parameters)
                           param-offset (double alpha) (double beta1) (double beta2)
                           (double epsilon) (double pow-beta1-t) (double pow-beta2-t)
-                          (.array m) (.array v)))
-  (nio-planar-input->convolution! [input ^DoubleBuffer input-convolved
+                          (.data m) (.data v)))
+  (cpu-planar-input->convolution! [input ^DoubleArrayView input-convolved
                                    ^ConvLayerConfig conv-config]
-    (nio-planar-input->convolution!-impl input input-convolved conv-config double))
-  (nio-convolution->planar-output! [input-convolved ^DoubleBuffer input-gradient
+    (cpu-planar-input->convolution!-impl input input-convolved conv-config double))
+  (cpu-convolution->planar-output! [input-convolved ^DoubleArrayView input-gradient
                                     ^ConvLayerConfig conv-config]
-    (nio-convolution->planar-output!-impl input-convolved input-gradient conv-config double))
+    (cpu-convolution->planar-output!-impl input-convolved input-gradient conv-config double))
 
-  (nio-fill [buffer value]
-    (Arrays/fill (.array buffer) (.arrayOffset buffer)
-                 (+ (.arrayOffset buffer) (.remaining buffer)) (double value)))
-  (nio-max-pooling-forward [input ^DoubleBuffer output ^ConvLayerConfig conv-config]
-    (nio-max-pooling-forward-impl input output conv-config double))
-  (nio-max-pooling-backward [input ^DoubleBuffer output ^DoubleBuffer input-gradient
-                             ^DoubleBuffer output-gradient ^ConvLayerConfig conv-config]
-    (nio-max-pooling-backward-impl input output input-gradient output-gradient conv-config
+  (cpu-fill [buffer value]
+    (Arrays/fill (.data buffer) (.offset buffer)
+                 (+ (.offset buffer) (.length buffer)) (double value)))
+  (cpu-max-pooling-forward [input ^DoubleArrayView output ^ConvLayerConfig conv-config]
+    (cpu-max-pooling-forward-impl input output conv-config double))
+  (cpu-max-pooling-backward [input ^DoubleArrayView output ^DoubleArrayView input-gradient
+                             ^DoubleArrayView output-gradient ^ConvLayerConfig conv-config]
+    (cpu-max-pooling-backward-impl input output input-gradient output-gradient conv-config
                                    double))
-  (nio-prepare-bernoulli-dropout [mult-buffer ^FloatBuffer rand-buffer probability]
-    (nio-prepare-bernoulli-impl mult-buffer rand-buffer probability double))
-  (nio-prepare-gaussian-dropout [mult-buffer ^FloatBuffer rand-buffer]
-    (nio-prepare-gaussian-impl mult-buffer rand-buffer double))
-  (nio-bn-calc [^DoubleBuffer input ^DoubleBuffer means ^DoubleBuffer variances
-                ^DoubleBuffer scale ^DoubleBuffer bias ^DoubleBuffer output
+  (cpu-prepare-bernoulli-dropout [mult-buffer ^FloatBuffer rand-buffer probability]
+    (cpu-prepare-bernoulli-impl mult-buffer rand-buffer probability double))
+  (cpu-prepare-gaussian-dropout [mult-buffer ^FloatBuffer rand-buffer]
+    (cpu-prepare-gaussian-impl mult-buffer rand-buffer double))
+  (cpu-bn-calc [^DoubleArrayView input ^DoubleArrayView means ^DoubleArrayView variances
+                ^DoubleArrayView scale ^DoubleArrayView bias ^DoubleArrayView output
                 batch-size batch-stride]
-    (nio-bn-calc-impl input means variances scale bias output batch-size batch-stride double))
-  (nio-update-means-variances [input
-                               ^DoubleBuffer running-means ^DoubleBuffer running-variances
-                               ^DoubleBuffer saved-means ^DoubleBuffer saved-variances
+    (cpu-bn-calc-impl input means variances scale bias output batch-size batch-stride double))
+  (cpu-update-means-variances [input
+                               ^DoubleArrayView running-means ^DoubleArrayView running-variances
+                               ^DoubleArrayView saved-means ^DoubleArrayView saved-variances
                                batch-size batch-stride ave-factor epsilon]
-    (nio-update-means-variances-impl input running-means running-variances
+    (cpu-update-means-variances-impl input running-means running-variances
                                      saved-means saved-variances
                                      batch-size batch-stride
                                      ave-factor epsilon double))
-  (nio-bn-backward [input ^DoubleBuffer means ^DoubleBuffer variances ^DoubleBuffer scale
-                    ^DoubleBuffer bias ^DoubleBuffer output ^DoubleBuffer scale-gradient
-                    ^DoubleBuffer bias-gradient ^DoubleBuffer input-gradient
-                    ^DoubleBuffer output-gradient batch-size batch-stride]
-    (nio-bn-backward-impl input means variances scale bias output scale-gradient bias-gradient
+  (cpu-bn-backward [input ^DoubleArrayView means ^DoubleArrayView variances ^DoubleArrayView scale
+                    ^DoubleArrayView bias ^DoubleArrayView output ^DoubleArrayView scale-gradient
+                    ^DoubleArrayView bias-gradient ^DoubleArrayView input-gradient
+                    ^DoubleArrayView output-gradient batch-size batch-stride]
+    (cpu-bn-backward-impl input means variances scale bias output scale-gradient bias-gradient
                           input-gradient output-gradient batch-size batch-stride double)))
 
 
-(extend-type FloatBuffer
-  PNIONetwork
-  (nio-activation-forward [input-buf act-type ^FloatBuffer output-buf]
-    (nio-act-forward-impl act-type input-buf output-buf float))
-  (nio-activation-backward [input act-type ^FloatBuffer output
-                            ^FloatBuffer output-gradient
-                            ^FloatBuffer input-gradient]
-    (nio-act-backward-impl act-type input output output-gradient input-gradient float))
-  (nio-softmax-forward [input-buf ^FloatBuffer output-buf ^long n-input]
-    (nio-softmax-forward-impl n-input input-buf output-buf float))
-  (nio-adadelta-step! [gradient ^FloatBuffer parameters gradient-alpha param-offset decay epsilon
-                       ^FloatBuffer grad-accum ^FloatBuffer dx-accum]
-    (AdadeltaOptimiser/step_f (float gradient-alpha) (.array gradient) (.array parameters)
+(extend-type FloatArrayView
+  PCPUNetworkImpl
+  (cpu-activation-forward [input-buf act-type ^FloatArrayView output-buf]
+    (cpu-act-forward-impl act-type input-buf output-buf float))
+  (cpu-activation-backward [input act-type ^FloatArrayView output
+                            ^FloatArrayView output-gradient
+                            ^FloatArrayView input-gradient]
+    (cpu-act-backward-impl act-type input output output-gradient input-gradient float))
+  (cpu-softmax-forward [input-buf ^FloatArrayView output-buf ^long n-input]
+    (cpu-softmax-forward-impl n-input input-buf output-buf float))
+  (cpu-adadelta-step! [gradient ^FloatArrayView parameters gradient-alpha param-offset decay epsilon
+                       ^FloatArrayView grad-accum ^FloatArrayView dx-accum]
+    (AdadeltaOptimiser/step_f (float gradient-alpha) (.data gradient) (.data parameters)
                               (int param-offset) (float decay) (float epsilon)
-                              (.array grad-accum) (.array dx-accum)))
-  (nio-adam-step! [gradient ^FloatBuffer parameters gradient-alpha param-offset
+                              (.data grad-accum) (.data dx-accum)))
+  (cpu-adam-step! [gradient ^FloatArrayView parameters gradient-alpha param-offset
                    alpha beta1 beta2 epsilon pow-beta1-t pow-beta2-t
-                   ^FloatBuffer m ^FloatBuffer v]
-    (AdamOptimiser/step_f (float gradient-alpha) (.array gradient) (.array parameters)
+                   ^FloatArrayView m ^FloatArrayView v]
+    (AdamOptimiser/step_f (float gradient-alpha) (.data gradient) (.data parameters)
                           param-offset (float alpha) (float beta1) (float beta2) (float epsilon)
-                          (float pow-beta1-t) (float pow-beta2-t) (.array m) (.array v)))
-  (nio-planar-input->convolution! [input ^FloatBuffer input-convolved
+                          (float pow-beta1-t) (float pow-beta2-t) (.data m) (.data v)))
+  (cpu-planar-input->convolution! [input ^FloatArrayView input-convolved
                                    ^ConvLayerConfig conv-config]
-    (nio-planar-input->convolution!-impl input input-convolved conv-config float))
-  (nio-convolution->planar-output! [input-convolved ^FloatBuffer input-gradient
+    (cpu-planar-input->convolution!-impl input input-convolved conv-config float))
+  (cpu-convolution->planar-output! [input-convolved ^FloatArrayView input-gradient
                                     ^ConvLayerConfig conv-config]
-    (nio-convolution->planar-output!-impl input-convolved input-gradient conv-config float))
-  (nio-fill [buffer value]
-    (Arrays/fill (.array buffer) (.arrayOffset buffer)
-                 (+ (.arrayOffset buffer) (.remaining buffer)) (float value)))
-  (nio-max-pooling-forward [input ^FloatBuffer output ^ConvLayerConfig conv-config]
-    (nio-max-pooling-forward-impl input output conv-config float))
-  (nio-max-pooling-backward [input ^FloatBuffer output ^FloatBuffer input-gradient
-                             ^FloatBuffer output-gradient ^ConvLayerConfig conv-config]
-    (nio-max-pooling-backward-impl input output input-gradient output-gradient conv-config
+    (cpu-convolution->planar-output!-impl input-convolved input-gradient conv-config float))
+  (cpu-fill [buffer value]
+    (Arrays/fill (.data buffer) (.offset buffer)
+                 (+ (.offset buffer) (.length buffer)) (float value)))
+  (cpu-max-pooling-forward [input ^FloatArrayView output ^ConvLayerConfig conv-config]
+    (cpu-max-pooling-forward-impl input output conv-config float))
+  (cpu-max-pooling-backward [input ^FloatArrayView output ^FloatArrayView input-gradient
+                             ^FloatArrayView output-gradient ^ConvLayerConfig conv-config]
+    (cpu-max-pooling-backward-impl input output input-gradient output-gradient conv-config
                                    float))
-  (nio-prepare-bernoulli-dropout [mult-buffer ^FloatBuffer rand-buffer probability]
-    (nio-prepare-bernoulli-impl mult-buffer rand-buffer probability float))
-  (nio-prepare-gaussian-dropout [mult-buffer ^FloatBuffer rand-buffer]
-    (nio-prepare-gaussian-impl mult-buffer rand-buffer float))
-  (nio-bn-calc [^FloatBuffer input ^FloatBuffer means ^FloatBuffer variances
-                ^FloatBuffer scale ^FloatBuffer bias ^FloatBuffer output
+  (cpu-prepare-bernoulli-dropout [mult-buffer ^FloatArrayView rand-buffer probability]
+    (cpu-prepare-bernoulli-impl mult-buffer rand-buffer probability float))
+  (cpu-prepare-gaussian-dropout [mult-buffer ^FloatArrayView rand-buffer]
+    (cpu-prepare-gaussian-impl mult-buffer rand-buffer float))
+  (cpu-bn-calc [^FloatArrayView input ^FloatArrayView means ^FloatArrayView variances
+                ^FloatArrayView scale ^FloatArrayView bias ^FloatArrayView output
                 batch-size batch-stride]
-    (nio-bn-calc-impl input means variances scale bias output batch-size batch-stride float))
-  (nio-update-means-variances [input
-                               ^FloatBuffer running-means ^FloatBuffer running-variances
-                               ^FloatBuffer saved-means ^FloatBuffer saved-variances
+    (cpu-bn-calc-impl input means variances scale bias output batch-size batch-stride float))
+  (cpu-update-means-variances [input
+                               ^FloatArrayView running-means ^FloatArrayView running-variances
+                               ^FloatArrayView saved-means ^FloatArrayView saved-variances
                                batch-size batch-stride ave-factor epsilon]
-    (nio-update-means-variances-impl input running-means running-variances
+    (cpu-update-means-variances-impl input running-means running-variances
                                      saved-means saved-variances
                                      batch-size batch-stride
                                      ave-factor epsilon float))
-  (nio-bn-backward [input ^FloatBuffer means ^FloatBuffer variances ^FloatBuffer scale
-                    ^FloatBuffer bias ^FloatBuffer output ^FloatBuffer scale-gradient
-                    ^FloatBuffer bias-gradient ^FloatBuffer input-gradient
-                    ^FloatBuffer output-gradient batch-size batch-stride]
-    (nio-bn-backward-impl input means variances scale bias output scale-gradient bias-gradient
+  (cpu-bn-backward [input ^FloatArrayView means ^FloatArrayView variances ^FloatArrayView scale
+                    ^FloatArrayView bias ^FloatArrayView output ^FloatArrayView scale-gradient
+                    ^FloatArrayView bias-gradient ^FloatArrayView input-gradient
+                    ^FloatArrayView output-gradient batch-size batch-stride]
+    (cpu-bn-backward-impl input means variances scale bias output scale-gradient bias-gradient
                           input-gradient output-gradient batch-size batch-stride float)))
 
 
 (defrecord ActivationLayer [act-type cpu-stream])
 
+
+(defn device-array->view
+  [dev-ary]
+  (dtype/->view (math/device-buffer dev-ary)))
+
+
 (extend-type ActivationLayer
   nn-backend/PBackendLayer
   (forward! [layer ^DeviceArray input ^DeviceArray output]
     (cpu-drv/with-stream-dispatch (.cpu-stream layer)
-      (nio-activation-forward (.device-buffer input) (.act-type layer) (.device-buffer output))))
+      (cpu-activation-forward (device-array->view input) (.act-type layer) (device-array->view output))))
   (backward! [layer ^DeviceArray input ^DeviceArray output
               ^DeviceArray input-gradient ^DeviceArray output-gradient]
     (cpu-drv/with-stream-dispatch (.cpu-stream layer)
-      (nio-activation-backward (.device-buffer input) (.act-type layer)
-                               (.device-buffer output)
-                               (.device-buffer output-gradient)
-                               (.device-buffer input-gradient)))))
+      (cpu-activation-backward (device-array->view input) (.act-type layer)
+                               (device-array->view output)
+                               (device-array->view output-gradient)
+                               (device-array->view input-gradient)))))
 
 (defrecord SoftmaxLayer [cpu-stream n-input])
 (extend-type SoftmaxLayer
   nn-backend/PBackendLayer
   (forward! [layer ^DeviceArray input ^DeviceArray output]
     (cpu-drv/with-stream-dispatch (.cpu-stream layer)
-      (nio-softmax-forward (.device-buffer input) (.device-buffer output) (.n-input layer))))
+      (cpu-softmax-forward (device-array->view input) (device-array->view output) (.n-input layer))))
   (backward! [layer ^DeviceArray input ^DeviceArray output
               ^DeviceArray input-gradient ^DeviceArray output-gradient]
     (layers/softmax-backward! (.cpu-stream layer) input-gradient output-gradient)))
@@ -670,8 +676,8 @@ in order to avoid adding a small number to 0."
       ;;*some* multithreading without having to explicity program much of it.
       (cpu-drv/with-stream-dispatch cpu-stream
         (doall (pmap (fn [[input output input-convolved]]
-                       (nio-planar-input->convolution! (math/device-buffer input)
-                                                       (math/device-buffer input-convolved)
+                       (cpu-planar-input->convolution! (device-array->view input)
+                                                       (device-array->view input-convolved)
                                                        (.conv-config layer))
                        ;;set the output to the bias...can't think of another way of doing this.
                        (math/gemm current-thread-stream true false
@@ -720,12 +726,12 @@ in order to avoid adding a small number to 0."
                                                (math/create-tensor num-out-channels
                                                                    num-out-pixels))]
                          ;;set input gradient at this batch location to empty
-                         (nio-fill (math/device-buffer input-gradient) 0)
+                         (cpu-fill (device-array->view input-gradient) 0)
                          (math/gemm current-thread-stream true false
                                     1.0 output-gradient weights
                                     0.0 input-convolved))
-                       (nio-convolution->planar-output! (math/device-buffer input-convolved)
-                                                        (math/device-buffer input-gradient)
+                       (cpu-convolution->planar-output! (device-array->view input-convolved)
+                                                        (device-array->view input-gradient)
                                                         conv-config))
                      io-data))))))
 
@@ -740,19 +746,19 @@ in order to avoid adding a small number to 0."
   (forward! [layer input output]
     (cpu-drv/with-stream-dispatch (drv/get-stream (.backend layer))
       (doall (pmap (fn [[input output]]
-                     (nio-max-pooling-forward (math/device-buffer input)
-                                              (math/device-buffer output)
+                     (cpu-max-pooling-forward (device-array->view input)
+                                              (device-array->view output)
                                               (.conv-config layer)))
                    (math/batched-data-to-per-input-data (drv/get-driver (.backend layer))
                                                         [input output])))))
   (backward! [layer input output input-gradient output-gradient]
     (cpu-drv/with-stream-dispatch (drv/get-stream (.backend layer))
       (doall (pmap (fn [[input output input-gradient output-gradient]]
-                     (nio-fill (math/device-buffer input-gradient) 0)
-                     (nio-max-pooling-backward (math/device-buffer input)
-                                               (math/device-buffer output)
-                                               (math/device-buffer input-gradient)
-                                               (math/device-buffer output-gradient)
+                     (cpu-fill (device-array->view input-gradient) 0)
+                     (cpu-max-pooling-backward (device-array->view input)
+                                               (device-array->view output)
+                                               (device-array->view input-gradient)
+                                               (device-array->view output-gradient)
                                                (.conv-config layer)))
                    (math/batched-data-to-per-input-data
                     (drv/get-driver (.backend layer))
@@ -765,12 +771,12 @@ in order to avoid adding a small number to 0."
   (batch-norm-calc! [layer input running-means running-variances scale bias output epsilon]
     (let [[batch-size batch-stride] (math/batch-shape input)]
      (cpu-drv/with-stream-dispatch (drv/get-stream (:backend layer))
-       (nio-bn-calc (math/device-buffer input)
-                    (math/device-buffer running-means)
-                    (math/device-buffer running-variances)
-                    (math/device-buffer scale)
-                    (math/device-buffer bias)
-                    (math/device-buffer output)
+       (cpu-bn-calc (device-array->view input)
+                    (device-array->view running-means)
+                    (device-array->view running-variances)
+                    (device-array->view scale)
+                    (device-array->view bias)
+                    (device-array->view output)
                     batch-size batch-stride))))
   (batch-norm-forward! [layer input
                         running-means running-variances
@@ -778,11 +784,11 @@ in order to avoid adding a small number to 0."
                         scale bias output average-factor epsilon]
     (let [[batch-size batch-stride] (math/batch-shape input)]
       (cpu-drv/with-stream-dispatch (drv/get-stream (:backend layer))
-       (nio-update-means-variances (math/device-buffer input)
-                                   (math/device-buffer running-means)
-                                   (math/device-buffer running-variances)
-                                   (math/device-buffer saved-means)
-                                   (math/device-buffer saved-variances)
+       (cpu-update-means-variances (device-array->view input)
+                                   (device-array->view running-means)
+                                   (device-array->view running-variances)
+                                   (device-array->view saved-means)
+                                   (device-array->view saved-variances)
                                    batch-size batch-stride
                                    average-factor epsilon)))
     (nn-backend/batch-norm-calc! layer input saved-means saved-variances
@@ -792,16 +798,16 @@ in order to avoid adding a small number to 0."
                          epsilon]
     (let [[batch-size batch-stride] (math/batch-shape input)]
      (cpu-drv/with-stream-dispatch (drv/get-stream (:backend layer))
-       (nio-bn-backward (math/device-buffer input)
-                        (math/device-buffer saved-means)
-                        (math/device-buffer saved-variances)
-                        (math/device-buffer scale)
-                        (math/device-buffer bias)
-                        (math/device-buffer output)
-                        (math/device-buffer scale-gradient)
-                        (math/device-buffer bias-gradient)
-                        (math/device-buffer input-gradient)
-                        (math/device-buffer output-gradient)
+       (cpu-bn-backward (device-array->view input)
+                        (device-array->view saved-means)
+                        (device-array->view saved-variances)
+                        (device-array->view scale)
+                        (device-array->view bias)
+                        (device-array->view output)
+                        (device-array->view scale-gradient)
+                        (device-array->view bias-gradient)
+                        (device-array->view input-gradient)
+                        (device-array->view output-gradient)
                         batch-size batch-stride)))))
 
 
@@ -847,9 +853,9 @@ in order to avoid adding a small number to 0."
              (cond
                (contains? #{:relu :tanh} recurrent-type)
                (cpu-drv/with-stream-dispatch (drv/get-stream backend)
-                 (nio-activation-forward (math/device-buffer iter-temp-out)
+                 (cpu-activation-forward (device-array->view iter-temp-out)
                                          recurrent-type
-                                         (math/device-buffer iter-output)))
+                                         (device-array->view iter-output)))
                :else
                (throw (Exception. "Unrecognized recurrence type")))
              (recur (inc idx) iter-output running-cell-state)))))))
@@ -863,11 +869,11 @@ in order to avoid adding a small number to 0."
      (cond
        (contains? #{:relu :tanh} recurrent-type)
        (cpu-drv/with-stream-dispatch (drv/get-stream backend)
-         (nio-activation-backward (math/device-buffer running-hidden-state)
+         (cpu-activation-backward (device-array->view running-hidden-state)
                                   recurrent-type
-                                  (math/device-buffer output)
-                                  (math/device-buffer output-gradient)
-                                  (math/device-buffer temp-out-gradient)))
+                                  (device-array->view output)
+                                  (device-array->view output-gradient)
+                                  (device-array->view temp-out-gradient)))
        :else
        (throw (Exception. "Unrecognized recurrence type")))
      (let [out-gradient-vec (split-array-into-batches temp-out-gradient)
@@ -933,22 +939,22 @@ in order to avoid adding a small number to 0."
                    gradient-alpha param-offset decay epsilon
                    ^DeviceArray grad-sq-accum ^DeviceArray dx-sq-accum]
     (cpu-drv/with-stream-dispatch (.stream backend)
-      (nio-adadelta-step! (.device-buffer gradient) (.device-buffer parameters)
+      (cpu-adadelta-step! (device-array->view gradient) (device-array->view parameters)
                           gradient-alpha param-offset decay epsilon
-                          (.device-buffer grad-sq-accum) (.device-buffer dx-sq-accum))))
+                          (device-array->view grad-sq-accum) (device-array->view dx-sq-accum))))
   (adam-step! [backend ^DeviceArray gradient ^DeviceArray parameters gradient-alpha param-offset
                alpha beta1 beta2 epsilon pow-beta1-t pow-beta2-t ^DeviceArray m ^DeviceArray v]
     (cpu-drv/with-stream-dispatch (.stream backend)
-      (nio-adam-step! (.device-buffer gradient) (.device-buffer parameters)
+      (cpu-adam-step! (device-array->view gradient) (device-array->view parameters)
                       gradient-alpha param-offset alpha beta1 beta2 epsilon
-                      pow-beta1-t pow-beta2-t (.device-buffer m) (.device-buffer v))))
+                      pow-beta1-t pow-beta2-t (device-array->view m) (device-array->view v))))
   nn-backend/PDropout
   (prepare-bernoulli-dropout! [backend probability rand-buffer mult-buffer]
     (cpu-drv/with-stream-dispatch (.stream backend)
-      (nio-prepare-bernoulli-dropout (math/device-buffer mult-buffer)
-                                     (math/device-buffer rand-buffer) probability)))
+      (cpu-prepare-bernoulli-dropout (device-array->view mult-buffer)
+                                     (device-array->view rand-buffer) probability)))
   ;;Gaussian distribution copied to mult buffer.
   (prepare-gaussian-dropout! [backend rand-buffer mult-buffer]
     (cpu-drv/with-stream-dispatch (.stream backend)
-      (nio-prepare-gaussian-dropout (math/device-buffer mult-buffer)
-                                    (math/device-buffer rand-buffer)))))
+      (cpu-prepare-gaussian-dropout (device-array->view mult-buffer)
+                                    (device-array->view rand-buffer)))))

--- a/compute/src/think/compute/nn/cpu_backend.clj
+++ b/compute/src/think/compute/nn/cpu_backend.clj
@@ -521,9 +521,9 @@ in order to avoid adding a small number to 0."
                              ^DoubleArrayView output-gradient ^ConvLayerConfig conv-config]
     (cpu-max-pooling-backward-impl input output input-gradient output-gradient conv-config
                                    double))
-  (cpu-prepare-bernoulli-dropout [mult-buffer ^FloatBuffer rand-buffer probability]
+  (cpu-prepare-bernoulli-dropout [mult-buffer ^FloatArrayView rand-buffer probability]
     (cpu-prepare-bernoulli-impl mult-buffer rand-buffer probability double))
-  (cpu-prepare-gaussian-dropout [mult-buffer ^FloatBuffer rand-buffer]
+  (cpu-prepare-gaussian-dropout [mult-buffer ^FloatArrayView rand-buffer]
     (cpu-prepare-gaussian-impl mult-buffer rand-buffer double))
   (cpu-bn-calc [^DoubleArrayView input ^DoubleArrayView means ^DoubleArrayView variances
                 ^DoubleArrayView scale ^DoubleArrayView bias ^DoubleArrayView output

--- a/gpu-compute/src/think/compute/cuda_driver.clj
+++ b/gpu-compute/src/think/compute/cuda_driver.clj
@@ -6,7 +6,8 @@
             [think.compute.javacpp-datatype :as jcpp-dtype]
             [clojure.core.matrix.protocols :as mp]
             [think.compute.math :as math]
-            [think.compute.cpu-driver :as cpu-drv])
+            [think.compute.cpu-driver :as cpu-drv]
+            [think.compute.math-util :as mu])
   (:import [org.bytedeco.javacpp cuda
             BytePointer IntPointer LongPointer DoublePointer
             Pointer PointerPointer FloatPointer ShortPointer
@@ -562,7 +563,7 @@ relies only on blockDim.x block.x and thread.x"
               B b-colstride
               beta C c-colstride
               ^CudaStream stream]
-    (cpu-drv/col->row-gemm
+    (mu/col->row-gemm
      (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
           alpha ^DoublePointer A a-rowstride
           ^DoublePointer B b-rowstride
@@ -594,7 +595,7 @@ relies only on blockDim.x block.x and thread.x"
      (double beta) y (int y-elem-count)
      res (int res-elem-count)))
   (cuda-gemv [A a-colstride x inc-x trans-a? a-row-count a-col-count alpha beta y inc-y stream]
-    (cpu-drv/col->row-gemv
+    (mu/col->row-gemv
      (fn [trans-a? a-row-count a-col-count
           alpha ^DoublePointer A a-rowstride
           ^DoublePointer x inc-x
@@ -644,7 +645,7 @@ relies only on blockDim.x block.x and thread.x"
               B b-colstride
               beta C c-colstride
               ^CudaStream stream]
-    (cpu-drv/col->row-gemm
+    (mu/col->row-gemm
      (fn [trans-a? trans-b? a-row-count a-col-count b-col-count
           alpha ^FloatPointer A a-rowstride
           ^FloatPointer B b-rowstride
@@ -677,7 +678,7 @@ relies only on blockDim.x block.x and thread.x"
                           (float beta) y (int y-elem-count)
                           res (int res-elem-count)))
   (cuda-gemv [A a-colstride x inc-x trans-a? a-row-count a-col-count alpha beta y inc-y stream]
-    (cpu-drv/col->row-gemv
+    (mu/col->row-gemv
      (fn [trans-a? a-row-count a-col-count
           alpha ^FloatPointer A a-rowstride
           ^FloatPointer x inc-x


### PR DESCRIPTION
Changed the underlying buffer representation for compute from nio buffers to array views.  

This will allow some greater compatibility with other clojure systems as they will also be backed by arrays at least in some cases (and will never be backed by nio buffers).  There may also be some perf benefit because arrays have native set/get methods while the nio buffer will always have a bit of a pathway *if* it is array backed.

