### PR TITLE
Keras scripts

### DIFF
--- a/keras/export/create_combined_h5.py
+++ b/keras/export/create_combined_h5.py
@@ -1,113 +1,30 @@
-'''
-This script produces an hdf5 file with outputs for each layer
-Will force inputs to be the 'tf' dimensionality ordering but supports both theano and tensorflow backends
-Inputs: 1) Model configuration (json, written out from keras using model.to_json())
-        2) weights (HDF5 written out from keras using model.save_weights())
-Outputs:  An HDF5 file containing
-        1) the output at each layer produced by a forward pass of the test-image
-        2) model configuration
-        3) weights
-        4) test-image
-'''
+"""
+This is a utility that takes the older style sidecar keras format convention
+of:
+
+arch.json
+weights.h5
+
+and combines them into the currently preferred single h5 file.
+
+Invoke as follows:
+
+python export/create_combined_h5.py arch.json weights.h5 combined.h5
+"""
+from __future__ import print_function # supports both 2/3
+
 import sys
-import json
-import h5py
-import numpy as np
-from keras.models import Sequential
-from keras.layers import Dense, Dropout, Activation, Flatten
-from keras.layers import Convolution2D, MaxPooling2D
-from keras.utils.layer_utils import layer_from_config
-
-def load_json(filename):
-    "Loads the model configuration file"
-    try:
-        with open (filename, 'r') as f:
-            data = f.read()
-        model_config = json.loads(data)
-        return model_config
-    except:
-        print "Error: Check if file exists and/or if it is valid json format"
+from keras.models import model_from_json
 
 
-def create_model(model_config):
-    "Creates a base model off of the class_name in the model config"
-    if (model_config.has_key('class_name') and model_config.has_key('config')):
-        model = eval(model_config['class_name'])()
-    else:
-        print "This json file has not been generated using keras - REDO and RERUN"
-        exit
-    return model
+json_file = sys.argv[1]
+weights_file = sys.argv[2]
+out_file = sys.argv[3]
 
-
-def load_weights(model, weights_path):
-    "Loads weights from the HDF5 file to the relevant layers"
-    f = h5py.File(weights_path)
-    layer_attr = f.attrs.keys()[0]
-    for k, layer in enumerate(f.attrs['layer_names']):
-        if k >= len(model.layers):
-            break
-        g = f[layer]
-        weights = [g[attr] for attr in g.keys()]
-        if len(weights) > 0:
-            model.layers[k].set_weights([weights[0], weights[1]])
-    f.close()
-    return model
-
-
-def construct_layers(layer_config, model, weights_path):
-    "Adds layers to the base model and loads weights onto each of those layers"
-    for config in layer_config:
-        model.add(layer_from_config(config))
-
-    print "Number of layers loaded {}".format(len(model.layers))
-    model_with_weights = load_weights(model, weights_path)
-    return model_with_weights
-
-
-def get_test_image(input_shape):
-    "Generates a test image of ones using the input_shape"
-    input_shape.insert(0, 1)
-    return np.ones(input_shape)
-
-
-def copy_weights(output_file, weights_file):
-    output_file.create_group('model_weights')
-
-    f = h5py.File(weights_file)
-    for layer in f.attrs['layer_names']:
-        f.copy(f[layer], output_file['model_weights'])
-    return output_file
-
-
-def generate_hdf5(config, weights_file):
-    "Writes an HDF5 file containing weights, model configuration and outputs at each layer"
-    model_config = config['config']
-    test_image = get_test_image(model_config[0]['config']['batch_input_shape'][1:])
-
-    f = h5py.File('decomposed_model.h5', 'w')
-    f['model_config'] = json.dumps(model_config)
-    f['test_image'] = test_image
-    layer_group = f.create_group('layer_outputs')
-
-    # Create new models incrementally by adding a layer each time and predict on the model
-    for i in range(0, len(model_config)):
-        model = create_model(config)
-        layer_name = "layer_{}_type_{}".format(i, model_config[i]['class_name'])
-        model = construct_layers(model_config[0:i+1], model, weights_file)
-        output = model.predict(test_image)
-        print "Output shape of the final layer {}\n".format(output.shape)
-        layer_group[layer_name] = output
-
-    # Write out the original weights to the new hdf5 file
-    f = copy_weights(f, weights_file)
-    f.close()
-    print "HDF5 file written"
-
-
-
-if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("Missing Input: model file and weights are required")
-        exit
-    else:
-        generate_hdf5(load_json(sys.argv[1]), sys.argv[2])
+with open(json_file) as jsonf:
+    m = model_from_json(jsonf.read())
+    m.load_weights(weights_file)
+    m.compile(optimizer='adam',
+              loss='categorical_crossentropy',
+              metrics=['accuracy'])
+    m.save(out_file)

--- a/keras/export/get_keras_output.py
+++ b/keras/export/get_keras_output.py
@@ -9,8 +9,8 @@ Outputs:  An HDF5 file containing
         1) the output at each layer produced by a forward pass of the test-image
         2) test-image
 '''
-import sys
 import h5py
+import argparse
 import numpy as np
 from keras import backend as K
 from keras.models import model_from_json, load_model
@@ -19,7 +19,7 @@ from keras.models import model_from_json, load_model
 MODEL_DEFAULTS = {
     "optimizer": "adam",
     "loss": "categorical_crossentropy",
-    "metrics": "accuracy"
+    "metrics": ["accuracy"],
 }
 
 
@@ -90,6 +90,27 @@ def layer_outputs(h5file, json_file=None, out_fname='layer_outputs.h5'):
 
 
 if __name__ == '__main__':
-    model_fname = sys.argv[1]
-    out_fname = sys.argv[2]
-    layer_outputs(model_fname, out_fname=out_fname)
+    parser = argparse.ArgumentParser()
+    arg = parser.add_argument
+    arg("h5_file",
+        help="The h5 model or weights file. If weights, specify --json")
+    arg("out_h5_file",
+        help="The h5 model to be generated that contains outputs.")
+    arg("--json", help="A json file containing the model's architecture.",
+        action="store", type=str, default=None)
+    args = parser.parse_args()
+
+    if not (args.h5_file and args.out_h5_file):
+        print("Missing required arguments, see help.")
+        exit()
+    if args.json:
+        layer_outputs(
+            args.h5_file,
+            json_file=args.json,
+            out_fname=args.out_h5_file,
+        )
+    else:
+        layer_outputs(
+            args.h5_file,
+            out_fname=args.out_h5_file,
+        )

--- a/keras/export/get_keras_output.py
+++ b/keras/export/get_keras_output.py
@@ -1,0 +1,95 @@
+from __future__ import print_function
+'''
+This script produces an hdf5 file with outputs for each layer.
+
+Inputs: 1) Model configuration (json, written out from keras using model.to_json())
+        2) weights (HDF5 written out from keras using model.save_weights())
+
+Outputs:  An HDF5 file containing
+        1) the output at each layer produced by a forward pass of the test-image
+        2) test-image
+'''
+import sys
+import h5py
+import numpy as np
+from keras import backend as K
+from keras.models import model_from_json, load_model
+
+
+MODEL_DEFAULTS = {
+    "optimizer": "adam",
+    "loss": "categorical_crossentropy",
+    "metrics": "accuracy"
+}
+
+
+def get_activations(model, layer, X_batch):
+    """Adapted from: https://github.com/fchollet/keras/issues/41 as a
+    workaround for perceived softmax issue. """
+    # phase 0 is test/inference, 1 is learning
+    phase = K.learning_phase()
+    get_activations = K.function(
+        [model.layers[0].input, phase],
+        [model.layers[layer].output],
+    )
+    activations = get_activations([X_batch, 0])
+    return activations
+
+
+def load_sidecar_model(arch_fname, weights_fname):
+    """Return a model saved by the previous keras standard format of
+    architecture in json, weights in h5 sidecar."""
+    with open(arch_fname, 'r') as json_file:
+        model = model_from_json(json_file.read())
+    model.load_weights(weights_fname)
+    # compile with sensible detfaults for typical n-way classifier, although
+    # we could possibly detect and handle different cases.
+    model.compile(**MODEL_DEFAULTS)
+    return model
+
+
+def load_single_model(fname):
+    """Wrapper for load_model that ensures model is compiled."""
+    m = load_model(fname)
+    try:
+        m.compile(**MODEL_DEFAULTS)
+    except:
+        return m
+
+
+def get_test_image(input_shape):
+    """Generates a test image of ones using the input_shape"""
+    input_shape[0] = 1
+    return np.ones(input_shape)
+
+
+def layer_outputs(h5file, json_file=None, out_fname='layer_outputs.h5'):
+    """Writes an HDF5 file containing outputs at each layer."""
+    if json_file:
+        model = load_sidecar_model(json_file, h5file)
+    else:
+        model = load_single_model(h5file)
+
+    input_dims = model.input.get_shape().as_list()
+    test_image = get_test_image(input_dims)
+
+    with h5py.File(out_fname, 'w') as outf:
+        outf['test_image'] = test_image
+        layer_group = outf.create_group('layer_outputs')
+
+        for i, lyr in enumerate(model.layers):
+            output = get_activations(model, i, test_image)
+
+            # output 0 is kind of a hack here, keras actually supports
+            # multiple outputs from a layer, although not common in modeling
+            # practice
+            layer_group[lyr.name] = output[0]
+
+        # Write out the original weights to the new hdf5 file
+        print("HDF5 file written: {0}".format(out_fname))
+
+
+if __name__ == '__main__':
+    model_fname = sys.argv[1]
+    out_fname = sys.argv[2]
+    layer_outputs(model_fname, out_fname=out_fname)


### PR DESCRIPTION
Improved model and some cleanup. This is opinionated in a way that changes the ingest pipeline:

* outputs per layer go into a sidecar h5 file.
* if we want layer descriptions/config in h5, go through the create_combined_h5.py (old name) script and generate the correct present version of the unified h5 model as per keras.
* guarantees aren't necessarily made for theano ordering. I think it's best to:
  * make tensorflow weight and model generation the blessed path.
  * if we want to munge between formats, use existing keras utilities or wrap them in our own script in a separate tool, e.g. a `th_to_tf.py`.

Some other comments:

* instead of rebuilding the model each time we use the keras backend function call that lets us generate the output by specifying the layer output we want by index.
* we still write the test image that's used to generate the input in the h5 file.

All in all this greatly simplifies the processing steps, makes the import process less brittle when unsupported layer types or configs fail to eval, and decouples model descriptions from the test files that we nee to reproduce keras model output.