### PR TITLE
[optimize] Check inputs to evaluate-softmax.

### DIFF
--- a/compute/src/think/compute/optimise.clj
+++ b/compute/src/think/compute/optimise.clj
@@ -218,6 +218,12 @@ buffers the param offset is required as the accumulation buffers are only one bu
 
 (defn evaluate-softmax
   [guesses answers]
+  (if (or (not (pos? (count guesses)))
+          (not (pos? (count answers)))
+          (not= (count guesses) (count answers)))
+    (throw (Exception. (format "evaluate-softmax: guesses [%d] and answers [%d] count must both be positive and equal."
+                               (count guesses)
+                               (count answers)))))
   (let [results-answer-seq (mapv vector
                                  (softmax-results-to-unit-vectors guesses)
                                  answers)


### PR DESCRIPTION
I ran into a null pointer exception when I increased the batch size without increasing the number of samples. This, at the very least, gives better output -- though perhaps this could be checked at a higher location (and or handled more gracefully)?