### PR TITLE
[gpu-compute] Don't make a call to initialize the card when loading t…

### DIFF
--- a/gpu-compute/src/think/compute/cuda_driver.clj
+++ b/gpu-compute/src/think/compute/cuda_driver.clj
@@ -92,8 +92,6 @@
        (throw (Exception. (format "cuRAND error: %s" (curand-error-to-string retval#)))))
      retval#))
 
-(defonce init-result (cuda-call (cuda/cuInit 0)))
-
 
 (defn zero-term-array-to-string
   [^"[B" byte-ary]


### PR DESCRIPTION
…he driver's namespace, as the namespace needs to be loaded during compilation which may occur on a machine that doesn't actually have a gpu attached.

I ran into an issue while trying to build a gpu-based cortex project. I am building the project on Travis CI, however the instances provided don't have GPUs attached to them. As such, I need to be able to compile the application with GPU support without making calls into the driver.