### PR TITLE
Print out epoch number when printing mse-loss

### DIFF
--- a/cortex/src/cortex/nn/network.cljc
+++ b/cortex/src/cortex/nn/network.cljc
@@ -119,7 +119,7 @@
                                 opt-network
                                 batch-index-seq)]
                     (when test-data
-                      (println "epoch mse-loss:" (evaluate-mse network test-data test-labels)))
+                      (println "epoch" @epoch-count " mse-loss:" (evaluate-mse network test-data test-labels)))
                     [optimizer network]))
                 [optimizer network]
                 epoch-batches)]


### PR DESCRIPTION
In the network/train function, there's an unused epoch-count atom keeping track of the current epoch. Might be useful to print out the current epoch number when printing out that epoch's result.