### PR TITLE
Upgrade think parallel

### DIFF
--- a/compute/project.clj
+++ b/compute/project.clj
@@ -5,7 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.2.391"]
-                 [thinktopic/resource "1.1.0"]
                  [thinktopic/datatype "0.1.0"]
                  [thinktopic/cortex "0.2.1-SNAPSHOT"]
                  [thinktopic/cortex-datasets "0.3.0-SNAPSHOT"]]

--- a/cortex/project.clj
+++ b/cortex/project.clj
@@ -11,7 +11,8 @@
                  [net.mikera/core.matrix "0.57.0"]
                  [net.mikera/clojure-utils "0.7.1"]
                  [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
-                 [thinktopic/think.parallel "0.1.0"]]
+                 [thinktopic/think.parallel "0.3.4"]
+                 [thinktopic/resource "1.1.0"]]
 
   :java-source-paths ["java"]
 

--- a/cortex/test/cljc/cortex/nn/scrabble_test.cljc
+++ b/cortex/test/cljc/cortex/nn/scrabble_test.cljc
@@ -63,13 +63,14 @@
        (clojure.string/join)
        (parse-int2)))
 
-(deftest scrabble-test []
+(deftest scrabble-test
+  []
   (let [training-data (into [] (for [k (keys scrabble-values)] (char->bit-array k)))
         training-labels (into [] (for [v (vals scrabble-values)] (num->bit-array v)))
         input-width (last (mat/shape training-data))
         output-width (last (mat/shape training-labels))
         hidden-layer-size 4
-        n-epochs 200
+        n-epochs 400
         batch-size 1
         loss-fn (opt/mse-loss)
         network (core/stack-module [(layers/linear-layer input-width hidden-layer-size)
@@ -80,4 +81,3 @@
 
       (is (= (classify trained-network \j) 8))
       (is (= (classify trained-network \k) 5))))
- 

--- a/suite/src/cortex/suite/classification.clj
+++ b/suite/src/cortex/suite/classification.clj
@@ -231,10 +231,8 @@ as it is training)."
 (defn per-epoch-eval-training-network
   [best-network-atom network-filename best-network-function
    epoch-idx {:keys [batching-system dataset network] :as train-config}]
-  (let [eval-labels (batch/get-cpu-labels batching-system :cross-validation)
-        {:keys [train-config avg-loss inferences labels]}
-        (train/evaluate-training-network
-         train-config eval-labels :cross-validation)
+  (let [{:keys [train-config avg-loss inferences labels]}
+        (train/evaluate-training-network train-config :cross-validation)
         avg-loss (double (first avg-loss))
         best-network-function
         (when best-network-function

--- a/suite/src/cortex/suite/classification.clj
+++ b/suite/src/cortex/suite/classification.clj
@@ -25,42 +25,40 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 
-(defn balanced-file-label-pairs
+(defn directory->file-label-seq
   "Given a directory with subdirs named after labels, produce an
 infinite interleaved sequence of [sub-dir-name sub-dir-file]
-to create balanced training classes using partition along with interleave."
-  [dirname & {:keys [infinite?]
-              :or {infinite? true}}]
-  (let [sub-dirs (.listFiles ^File (io/file dirname))]
-    (->> sub-dirs
-         (map (fn [^File sub-dir]
-                (map vector
-                     (if infinite?
-                       (mapcat shuffle
-                               (repeatedly #(seq (.listFiles sub-dir))))
-                       (seq (.listFiles sub-dir)))
-                     (repeat (.getName sub-dir)))))
-         (apply interleave))))
+to create balanced training classes using partition along with interleave.
+Class balance is only guaranteed if the sequence is infinite or if
+each directory has the same number of files."
+  [dirname infinite?]
+  (let [sub-dirs (.listFiles ^File (io/file dirname))
+        file-sequences  (->> sub-dirs
+                             (map (fn [^File sub-dir]
+                                    (map vector
+                                     (if infinite?
+                                       (mapcat shuffle
+                                               (repeatedly #(seq (.listFiles sub-dir))))
+                                       (seq (.listFiles sub-dir)))
+                                     (repeat (.getName sub-dir))))))]
+    (if infinite?
+      (apply interleave file-sequences)
+      (mapcat identity file-sequences))))
 
 
-(defn infinite-semi-balanced-observation-label-pairs
-  "Create a balanced infinite sequence of labels and patches.
-Assumptions are that the src-item-seq is balanced by class
-and that the transformation from src item to a list of [label, patch]
-maintaines that class balance meaning applying that either produces
-roughly uniform sequences of label->patch.  The transformation from
-src item -> patch will be done in a threaded pool and fed into a queue
-with the result further slighly interleaved.
-
-The final results will be pulled out of the sequence and shuffled so assuming
-your epoch element count is large enough the result will still be balanced and
-random regardless of this function's specific behavior for any specific src item."
-  [src-item-seq item->patch-seq-fn & {:keys [queue-size]
-                                      :or {queue-size 1000}}]
-  (let [{:keys [sequence shutdown-fn]} (parallel/queued-sequence queue-size
-                                                                 (* 2 (.availableProcessors (Runtime/getRuntime)))
-                                                                 item->patch-seq-fn
-                                                                 src-item-seq)]
+(defn src-seq->obs-seq
+  "Perform a transformation from a src sequence to a obs-sequence
+assuming the src->obs transformation itself produces potentially a sequence
+of observations for a single src item.  Perform this transformation
+in an offline thread pool storing allowing up to queue-size transformed
+sequences in memory.  Return a combination of observations and
+a shutdown function to be used in the case where the input sequence
+is infinite."
+  [src-item-seq src-item->obs-seq-fn & {:keys [queue-size]
+                                          :or {queue-size 100}}]
+  (let [{:keys [sequence shutdown-fn]} (parallel/queued-sequence src-item->obs-seq-fn
+                                                                 [src-item-seq]
+                                                                 :queue-size queue-size)]
     {:observations (mapcat identity sequence)
      :shutdown-fn shutdown-fn}))
 
@@ -82,40 +80,82 @@ random regardless of this function's specific behavior for any specific src item
 
 
 (defn create-classification-dataset
-  ([class-names data-shape cv-data-label-pairs holdout-data-label-pairs
-    infinite-training-data-label-pairs-seq epoch-element-count
-    & {:keys [epoch-repeat-count]
-       :or {epoch-repeat-count 1}}]
+  ([class-names data-shape
+    cv-epoch-seq
+    holdout-epoch-seq
+    training-epoch-seq
+    & {:keys [shutdown-fn]}]
    (let [label->vec (create-label->vec-fn class-names)
          seq-transform-fn #(map (fn [[data label]]
                                   [data (label->vec label)])
                                 %)
-         cv-seq (seq-transform-fn cv-data-label-pairs)
-         holdout-seq (seq-transform-fn holdout-data-label-pairs)
-         training-seq (seq-transform-fn infinite-training-data-label-pairs-seq)
+         cv-epoch-seq (map seq-transform-fn cv-epoch-seq)
+         holdout-epoch-seq (map seq-transform-fn holdout-epoch-seq)
+         training-epoch-seq (map seq-transform-fn training-epoch-seq)
          dataset (ds/create-infinite-dataset [[:data data-shape]
                                               [:labels (count class-names)]]
-                                             cv-seq holdout-seq training-seq
-                                             epoch-element-count
-                                             :epoch-repeat-count epoch-repeat-count)]
+                                             cv-epoch-seq
+                                             holdout-epoch-seq
+                                             training-epoch-seq
+                                             :shutdown-fn
+                                             shutdown-fn)]
      (assoc dataset :class-names class-names))))
 
 
-(defn create-classification-dataset-from-labeled-image-subdirs
+(defn get-class-names-from-directory
+  [dirname]
+  (vec (map #(.getName ^File %) (.listFiles (io/file dirname)))))
+
+
+(defn labelled-subdirs->obs-label-seq
+  "Given labelled subdirs produce a possibly infinite (balanced) sequence
+of data or a finite potentially unbalanced sequence of data.
+Returns map of {:observations :shutdown-fn}."
+  [dirname infinite? queue-size file-label->obs-label-seq-fn]
+  (-> (directory->file-label-seq dirname infinite?)
+      (src-seq->obs-seq file-label->obs-label-seq-fn :queue-size queue-size)))
+
+
+(defn create-classification-dataset-from-labeled-data-subdirs
   "Given a directory name and a function that can transform
 a single [^File file ^String sub-dir-name] into a sequence of
 [observation label] pairs produce a classification dataset.
 Queue size should be the number of obs-label-seqs it will take
 to add up to epoch-element-count.  This is a property of
 file-lable->obs-lable-seq-fn."
-  [dirname data-shape file-label->obs-label-seq-fn & {:keys [queue-size epoch-element-count]
-                                                      :or {queue-size 1000
-                                                epoch-element-count 10000}}]
-  (let [file-pairs (balanced-file-label-pairs dirname)
-        observations (infinite-semi-balanced-observation-label-pairs file-pairs
-                                                                     file-label->obs-label-seq-fn)
-        class-names (mapv #(.getName ^File %) (.listFiles ^File (io/file dirname)))]
-    (create-classification-dataset class-names data-shape observations epoch-element-count)))
+  [train-dirname test-dirname
+   data-shape
+   ;;training probably means augmentation
+   train-file-label->obs-label-seq-fn
+   ;;test means no augmentation
+   test-file-label->obs-label-seq-fn
+   & {:keys [queue-size epoch-element-count]
+      :or {queue-size 100
+           epoch-element-count 10000}}]
+
+  (let [class-names (get-class-names-from-directory test-dirname)
+        _ (when-not (= class-names (get-class-names-from-directory train-dirname))
+            (throw (ex-info "Class names for test and train do not match"
+                            {:train-class-names (get-class-names-from-directory train-dirname)
+                             :test-class-names class-names})))
+        cv-holdout-epoch-seq (map :observations
+                                  (repeatedly #(labelled-subdirs->obs-label-seq
+                                                test-dirname
+                                                false
+                                                queue-size
+                                                test-file-label->obs-label-seq-fn)))
+        {:keys [observations shutdown-fn]} (labelled-subdirs->obs-label-seq
+                                            train-dirname true queue-size
+                                            train-file-label->obs-label-seq-fn)
+        ;;An entire epoch of training data has to fit in memory for us to maintain that
+        ;;one file can produce n identically labelled items
+        training-epoch-seq (map shuffle (partition epoch-element-count observations))]
+    (create-classification-dataset class-names data-shape
+                                   cv-holdout-epoch-seq
+                                   cv-holdout-epoch-seq
+                                   training-epoch-seq
+                                   :shutdown-fn
+                                   shutdown-fn)))
 
 
 (defn image-network-description
@@ -333,10 +373,15 @@ a vector of class names that are used to derive labels for the network inference
 (defn batch-sequence->panel
   ^JPanel [vec->label-fn observation->img-fn dataset batch-type]
   (let [batch-sequence (ds/get-batches dataset 25 batch-type [:data :labels])
-        batch-data (first batch-sequence)
-        interleaved-data (partition 2 (apply interleave batch-data))]
+        epoch-data (mapcat #(partition 2 (apply interleave %)) batch-sequence)
+        interleaved-data (take 100 (if-not (= batch-type :training)
+                                     ;;cv and holdout data may not be shuffled enough
+                                     ;;to get a representative set.  We expect training
+                                     ;;data to be pretty balanced, however.
+                                     (shuffle epoch-data)
+                                     epoch-data))]
     (let [^JPanel top-panel (border-layout-panel)
-          ^JPanel outer-grid (grid-layout-panel 5 5)]
+          ^JPanel outer-grid (grid-layout-panel 0 5)]
       (.add top-panel (->label (name batch-type)) BorderLayout/NORTH)
       (.add top-panel outer-grid BorderLayout/CENTER)
       (.setBorder top-panel (BorderFactory/createLineBorder Color/BLACK 2))


### PR DESCRIPTION
Large upgrade using new think.parallel features and enabling training on lower memory systems (albeit with higher gc usage).

1.  Change the batching and training system so that when doing inference we can pull out the labels from the dataset without needing to realize all the batches it separately from doing inference on them.  This was a difficult change but it makes doing work with a very large dataset a bit easier.

2.  Changed the infinite dataset definition such that the cross-validation, holdout, and training sets are sequences of epochs of data.  This allows, for instance, a clever implementation to produce cross-validation data on demand instead of pre-calculating it thus greatly reducing overall memory requirements.  

3.  Worked through the classification model and added a faster path when someone has already separated their data into training and testing directories.  In that case the setup time is now significantly less with less confusing code.  