### PR TITLE
add codox plugin to projects

### DIFF
--- a/caffe/project.clj
+++ b/caffe/project.clj
@@ -6,4 +6,5 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [thinktopic/hdf5 "0.1.2"]
                  [thinktopic/compute "0.3.1-SNAPSHOT"]
-                 [instaparse "1.4.3"]])
+                 [instaparse "1.4.3"]]
+  :plugins [[lein-codox "0.10.2"]])

--- a/compute/project.clj
+++ b/compute/project.clj
@@ -9,4 +9,5 @@
                  [thinktopic/cortex "0.3.1-SNAPSHOT"]
                  [thinktopic/cortex-datasets "0.3.1-SNAPSHOT"]]
   :java-source-paths ["java"]
+  :plugins [[lein-codox "0.10.2"]]
   )

--- a/cortex/project.clj
+++ b/cortex/project.clj
@@ -50,6 +50,8 @@
 
   :resource-paths ["resources"]
 
+  :plugins [[lein-codox "0.10.2"]]
+  
   :jvm-opts  ["-Xmx8g"
               "-XX:+UseConcMarkSweepGC"
               "-XX:-OmitStackTraceInFastThrow"]

--- a/datasets/project.clj
+++ b/datasets/project.clj
@@ -8,4 +8,5 @@
                  [net.mikera/core.matrix "0.50.0"]
                  [thinktopic/resource "1.1.0"]
                  [com.indeed/util-mmap "1.0.20"]
-                 [com.github.ben-manes.caffeine/caffeine "2.3.1"]])
+                 [com.github.ben-manes.caffeine/caffeine "2.3.1"]]
+  :plugins [[lein-codox "0.10.2"]])

--- a/gpu-compute/project.clj
+++ b/gpu-compute/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.bytedeco.javacpp-presets/cuda "7.5-1.2"]
-                 [thinktopic/compute "0.3.1-SNAPSHOT"]])
+                 [thinktopic/compute "0.3.1-SNAPSHOT"]]
+  :plugins [[lein-codox "0.10.2"]])

--- a/keras/project.clj
+++ b/keras/project.clj
@@ -9,7 +9,8 @@
                  [cheshire "5.6.3"]
                  [thinktopic/compute "0.3.1-SNAPSHOT"]
                  [net.mikera/imagez "0.10.0"]]
-  :plugins [[s3-wagon-private "1.1.2"]]
+  :plugins [[s3-wagon-private "1.1.2"]
+            [lein-codox "0.10.2"]]
   :repositories  {"snapshots"  {:url "s3p://thinktopic.jars/snapshots/"
                                 :passphrase :env
                                 :username :env

--- a/suite/project.clj
+++ b/suite/project.clj
@@ -8,4 +8,5 @@
                  [thinktopic/think.image "0.4.2"]
                  [com.taoensso/nippy "2.12.2"]
                  [garden "1.3.2"]]
-  :resource-paths ["cljs"])
+  :resource-paths ["cljs"]
+  :plugins [[lein-codox "0.10.2"]])

--- a/visualization/project.clj
+++ b/visualization/project.clj
@@ -8,4 +8,5 @@
                  [incanter/incanter-core "1.5.7"]
                  [incanter/incanter-charts "1.5.7"]
                  [thinktopic/think.image "0.4.2"]
-                 [thinktopic/cortex "0.3.1-SNAPSHOT"]])
+                 [thinktopic/cortex "0.3.1-SNAPSHOT"]]
+  :plugins [[lein-codox "0.10.2"]])


### PR DESCRIPTION
just adding in codox for generating html docs.  

suite, visualization, and gpu-compute don't complete successfully.  With suite and gpu-compute that has to do with jnicuda, for instance:

    java.lang.UnsatisfiedLinkError: no jnicuda in java.library.path, compiling:(think/compute/cuda_driver.clj:104:5)

visualization fails because it things m/add-outer-product! doesn't exist - codox may be pulling in the wrong version of core.matrix somehow.  

At any rate, the other five  projects succeed with lein codox.  