### PR TITLE
Fix typo in label-one example

### DIFF
--- a/examples/suite-classification/src/suite_classification/core.clj
+++ b/examples/suite-classification/src/suite_classification/core.clj
@@ -238,7 +238,7 @@ to avoid overfitting the network to the training data."
     (imagez/show test-img)
     (infer/classify-one-observation (:network-description
                                      (suite-io/read-nippy-file "trained-network.nippy"))
-                                    observation (ds/create-image-shape mnist-num-classes
+                                    observation (ds/create-image-shape mnist-num-channels
                                                                        mnist-image-size
                                                                        mnist-image-size)
                                     mnist-datatype (classification/get-class-names-from-directory "mnist/testing"))))


### PR DESCRIPTION
The image shape should be number of channels not the number of classes