### PR TITLE
Non trainable parameters

### DIFF
--- a/caffe/src/caffe/core.clj
+++ b/caffe/src/caffe/core.clj
@@ -9,7 +9,7 @@
             [clojure.core.matrix.macros :refer [c-for]]
             [cortex.verify.nn.import :as verify-import]
             [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [think.compute.nn.compute-execute :as compute-execute])
   (:import [java.io StringReader]))
 
@@ -279,7 +279,7 @@ whitespace = #'\\s*'") parse-str)]
                           desc))
                       model)]
       {:prototxt prototxt
-       :model (build/build-network model)
+       :model (network/build-network model)
        :input input
        :layer-outputs layer-outputs})))
 

--- a/cortex/src/cortex/nn/network.clj
+++ b/cortex/src/cortex/nn/network.clj
@@ -358,6 +358,17 @@ attenuation is 0 will happen."
                        buffers (get-in network [:layer-graph :buffers (get param :buffer-id)])
                        retval (merge param-desc param buffers)]
                    (assoc retval
+                          :learning-attenuation
+                          (or (get retval :learning-attenuation)
+                              (double (get node :learning-attenuation 1.0)))
                           :non-trainable?
                           (or (get retval :non-trainable?)
+                              (get node :non-trainable?)
                               (= 0.0 (double (get node :learning-attenuation 1.0)))))))))))
+
+
+(defn any-trainable-parameters?
+  [network node-id]
+  (->> (get-node-parameters network node-id)
+       (remove :non-trainable?)
+       seq))

--- a/cortex/src/cortex/verify/nn/gradient.clj
+++ b/cortex/src/cortex/verify/nn/gradient.clj
@@ -1,7 +1,7 @@
 (ns cortex.verify.nn.gradient
   (:require [cortex.nn.execute :as execute]
             [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [cortex.nn.traverse :as traverse]
             [cortex.nn.protocols :as cp]
             [cortex.verify.utils :as utils]
@@ -46,7 +46,7 @@
     (as-> (-> network
               (assoc-in [0 :id] :input)
               (assoc-in [(- num-items 1) :id] test-id)) network
-      (build/build-network network)
+      (network/build-network network)
       (traverse/bind-input-bindings network input-bindings)
       (traverse/bind-output-bindings network output-bindings)
       (assoc network :batch-size batch-size)

--- a/cortex/src/cortex/verify/nn/gradient.clj
+++ b/cortex/src/cortex/verify/nn/gradient.clj
@@ -50,7 +50,7 @@
       (traverse/bind-input-bindings network input-bindings)
       (traverse/bind-output-bindings network output-bindings)
       (assoc network :batch-size batch-size)
-      (traverse/network->training-traversal network)
+      (traverse/network->training-traversal network :keep-non-trainable? true)
       (cp/bind-to-network context network {:numeric-gradients? true})
       (cp/generate-numeric-gradients context network
                                      {:data input

--- a/cortex/src/cortex/verify/nn/import.clj
+++ b/cortex/src/cortex/verify/nn/import.clj
@@ -1,5 +1,5 @@
 (ns cortex.verify.nn.import
-  (:require [cortex.nn.build :as build]
+  (:require [cortex.nn.network :as network]
             [cortex.nn.traverse :as traverse]
             [cortex.nn.execute :as execute]
             [cortex.nn.protocols :as cp]
@@ -12,14 +12,14 @@
 (defn verify-model
   ([context network input layer-output-vec]
    (when-not (contains? network :layer-graph)
-     (throw (ex-info "Network appears to not be built (cortex.nn.build/build-network)"
+     (throw (ex-info "Network appears to not be built (cortex.nn.network/build-network)"
                      {:network-keys (try (keys network)
                                          (catch Exception e []))})))
    (when-let [failures (seq (get network :verification-failures))]
      (throw (Exception. (format "Description verification failed:\n %s"
                                 (with-out-str (clojure.pprint/pprint failures))))))
    (resource/with-resource-context
-     (let [[roots leaves] (build/edges->roots-and-leaves (get-in network [:layer-graph :edges]))
+     (let [[roots leaves] (network/edges->roots-and-leaves (get-in network [:layer-graph :edges]))
            input-bindings {(first roots) :data}
            output-bindings (->> leaves
                                 (map #(vector % {}))

--- a/cortex/src/cortex/verify/nn/layers.clj
+++ b/cortex/src/cortex/verify/nn/layers.clj
@@ -24,7 +24,7 @@
       (network/build-network network)
       (traverse/bind-input-bindings network input-bindings)
       (traverse/bind-output-bindings network output-bindings)
-      (traverse/network->training-traversal network)
+      (traverse/network->training-traversal network :keep-non-trainable? true)
       (assoc network :batch-size batch-size)
       (cp/bind-to-network context network {}))))
 

--- a/cortex/src/cortex/verify/nn/layers.clj
+++ b/cortex/src/cortex/verify/nn/layers.clj
@@ -1,7 +1,7 @@
 (ns cortex.verify.nn.layers
   "Verify that layers do actually produce their advertised results."
   (:require [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [cortex.nn.traverse :as traverse]
             [cortex.nn.execute :as execute]
             [clojure.test :refer :all]
@@ -21,7 +21,7 @@
       (vec network)
       (assoc-in network [0 :id] :input)
       (assoc-in network [1 :id] test-layer-id)
-      (build/build-network network)
+      (network/build-network network)
       (traverse/bind-input-bindings network input-bindings)
       (traverse/bind-output-bindings network output-bindings)
       (traverse/network->training-traversal network)

--- a/cortex/src/cortex/verify/nn/train.clj
+++ b/cortex/src/cortex/verify/nn/train.clj
@@ -2,7 +2,7 @@
   (:require [cortex.nn.layers :as layers]
             [cortex.nn.execute :as execute]
             [cortex.nn.traverse :as traverse]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [cortex.dataset :as ds]
             [cortex.loss :as loss]
             [cortex-datasets.mnist :as mnist]
@@ -83,7 +83,7 @@
    n-epochs map-fn]
   (let [output-id (ffirst output-bindings)]
    (resource/with-resource-context
-     (as-> (build/build-network network) net-or-seq
+     (as-> (network/build-network network) net-or-seq
        (execute/train context net-or-seq dataset input-bindings output-bindings
                       :batch-size batch-size
                       :optimiser optimiser

--- a/cortex/test/clj/cortex/nn/network_test.clj
+++ b/cortex/test/clj/cortex/nn/network_test.clj
@@ -1,7 +1,7 @@
-(ns cortex.nn.build-test
+(ns cortex.nn.network-test
   (:require [clojure.test :refer :all]
             [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [clojure.core.matrix :as m]))
 
 
@@ -9,7 +9,7 @@
 (deftest specify-weights-bias
   (let [weight-data [[1 2][3 4]]
         bias-data [0 10]
-        built-network (build/build-network [(layers/input 2)
+        built-network (network/build-network [(layers/input 2)
                                             (layers/linear
                                              2
                                              :weights {:buffer weight-data}

--- a/cortex/test/clj/cortex/nn/traverse_test.clj
+++ b/cortex/test/clj/cortex/nn/traverse_test.clj
@@ -1,7 +1,7 @@
 (ns cortex.nn.traverse-test
   (:require [cortex.nn.traverse :as traverse]
             [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [clojure.test :refer :all]
             [clojure.core.matrix :as m]
             [cortex.loss :as loss]
@@ -56,7 +56,7 @@
 (deftest build-big-description
   (let [input-bindings [(traverse/->input-binding :input-1 :data)]
         output-bindings [(traverse/->output-binding :softmax-1 :stream :labels :loss (loss/softmax-loss))]
-        network (-> (build/build-network mnist-description-with-toys)
+        network (-> (network/build-network mnist-description-with-toys)
                     (traverse/bind-input-bindings input-bindings)
                     (traverse/bind-output-bindings output-bindings))
         gradient-descent (->> (traverse/network->training-traversal network)

--- a/keras/src/think/cortex/keras/core.clj
+++ b/keras/src/think/cortex/keras/core.clj
@@ -1,7 +1,7 @@
 (ns think.cortex.keras.core
   (:require [think.hdf5.core :as hdf5]
             [cortex.nn.layers :as layers]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [cortex.nn.traverse :as traverse]
             [think.resource.core :as resource]
             [cheshire.core :as json]
@@ -371,7 +371,7 @@ produce a new array of double values in the order desired"
                                     :weights weight-double-data
                                     :bias (ensure-doubles (:data (hdf5/->clj bias-ds))))))
                          desc))))
-             build/build-network)]
+             network/build-network)]
     (when-let [verify-seq (seq (get network :verification-failures))]
       (throw (ex-info "Built items failed verification"
                       {:verification-failures  (vec verify-seq)})))
@@ -552,7 +552,7 @@ network."
                    :report (let [model-desc (-> json-file
                                                 read-model
                                                 model->simple-description)
-                                 network (build/build-network model-desc)
+                                 network (network/build-network model-desc)
                                  outputs (network-output-file->outputs network (hdf5/open-file output-file))]
                              (check-output-dims network outputs))}))))))
 

--- a/suite/src/cortex/suite/classification.clj
+++ b/suite/src/cortex/suite/classification.clj
@@ -14,7 +14,7 @@
             [cortex.suite.train :as suite-train]
             [cortex.loss :as loss]
             [cortex.nn.traverse :as traverse]
-            [cortex.nn.build :as build])
+            [cortex.nn.network :as network])
   (:import [java.io File]))
 
 
@@ -360,7 +360,7 @@ training will continue from there."
    & {:keys [epoch-count batch-size confusion-matrix-atom]
       :or {batch-size 128
            confusion-matrix-atom (atom {})}}]
-  (let [network (-> (build/build-network initial-description)
+  (let [network (-> (network/build-network initial-description)
                     traverse/auto-bind-io)]
    (doseq [_ (repeatedly
               #(suite-train/train-n dataset initial-description network

--- a/suite/src/cortex/suite/inference.clj
+++ b/suite/src/cortex/suite/inference.clj
@@ -4,7 +4,7 @@
             [think.compute.nn.compute-execute :as ce]
             [cortex.nn.execute :as execute]
             [cortex.nn.traverse :as traverse]
-            [cortex.nn.build :as build]
+            [cortex.nn.network :as network]
             [cortex.loss :as loss]))
 
 
@@ -29,7 +29,7 @@
         dataset (ds/->InMemoryDataset {:data {:data observations
                                               :shape observation-dataset-shape}}
                                       (vec (range (count observations))))
-        [roots leaves] (build/edges->roots-and-leaves (get-in network [:layer-graph :edges]))]
+        [roots leaves] (network/edges->roots-and-leaves (network/network->edges network))]
     (when-not (= 1 (count roots))
       (throw (ex-info "Network must have exactly 1 root for infer-n-observations"
                       {:roots roots})))

--- a/suite/src/cortex/suite/train.clj
+++ b/suite/src/cortex/suite/train.clj
@@ -10,8 +10,7 @@
             [think.compute.nn.cuda-backend :as cuda-backend]
             [cortex.nn.execute :as execute]
             [cortex.nn.traverse :as traverse]
-            [cortex.optimise :as cortex-opt]
-            [cortex.nn.build :as build]))
+            [cortex.optimise :as cortex-opt]))
 
 
 (defn load-network


### PR DESCRIPTION
1.  Rename build.clj to network.clj
2.  Move the build-desc function into layers so that a layer can be defined completely in layers.clj.
3.  Move a few algorithms from compute_execute.clj up into respective locations in either network.clj or traverse.clj.
4.  Implement support for non-trainable parameters in network.clj and traverse.clj.
5.  Fix fallout from things like the system detecting a unit test has no trainable parameters and thus not creating buffers or a backward pass for it (and then the test failing).