### PR TITLE
Add an option to lein run to see the live-updates

### DIFF
--- a/examples/suite-classification/README.md
+++ b/examples/suite-classification/README.md
@@ -1,3 +1,4 @@
+
 # suite-classification
 
 This example shows of some use of the continual training with a convolutional neural network with visualization as well as inference with a random image from the dataset. It uses the classic MNIST handwritten digit corpus. The training of the dataset using augmentation, to slightly change the image, for continual training.
@@ -12,7 +13,7 @@ _If you have CUDA-8.0 installed before you run the example, please uncomment the
 You might need to install the versions of the snapshots locally for the projects. If you do, you can do it from the main project directory. Run `local-install.sh`
 
 
-Then run `lein run`
+Then run `lein run live-updates`
 
 ```
 13:02 $ lein run

--- a/examples/suite-classification/src/suite_classification/main.clj
+++ b/examples/suite-classification/src/suite_classification/main.clj
@@ -4,4 +4,6 @@
 (defn -main
   [& args]
   (require 'suite-classification.core)
-  ((resolve 'suite-classification.core/train-forever-uberjar)))
+  (if (= "live-updates" (first args))
+    ((resolve 'suite-classification.core/train-forever))
+    ((resolve 'suite-classification.core/train-forever-uberjar))))


### PR DESCRIPTION
I took a closer look at https://github.com/thinktopic/cortex/pull/69 and recloned the repo and tried to run the example using `lein run`and found a problem with the web page displaying.

When the repo is cloned, there is just an empty resources directory https://github.com/thinktopic/cortex/tree/master/examples/suite-classification/resources.

Found that the assets never got generated and the webpage didn't show up because the main default is `train-forever-uberjar` https://github.com/thinktopic/cortex/blob/master/examples/suite-classification/src/suite_classification/main.clj#L7 which does not set the live-updates? to true to make the think.gate figwheel kick-off https://github.com/thinktopic/think.gate/blob/master/src/clj/think/gate/core.clj#L131

@harold once live-updates does get set to true, everything is great and taken care of for the user.

I added an option to the main to pass in an argument to trigger the displaying/ compiling of the web page. I also documented the README with the option. Feedback on another solution is welcome.