### PR TITLE
fixes the network-eval->cm bug

### DIFF
--- a/suite/src/cortex/suite/classification.clj
+++ b/suite/src/cortex/suite/classification.clj
@@ -181,21 +181,22 @@ as it is training)."
 (defn network-eval->rich-confusion-matrix
   "A rich confusion matrix is a confusion matrix with the list of inferences and
 observations in each cell instead of just a count."
-  [dataset {:keys [labels inferences data] :as network-eval}]
+  [dataset {:keys [labels inferences data leaf-node] :as network-eval}]
   (reset! last-network-eval network-eval)
   (let [class-names (get dataset :class-names)
         vec->label #(class-names (loss/max-index (vec %)))
-        _ (when-not (and (map? inferences)
+        _ (when-not (and (= (count leaf-node) 1)
                          (contains? labels :labels)
                          (contains? data :data))
-            (throw (ex-info "Classification datasets should have :output :labels and :data."
+            (throw (ex-info "Classification datasets should have :labels and :data and one leaf node with corresponding inferences."
                             {:input (keys data)
                              :labels (keys labels)
-                             :inferences (keys inferences)})))
+                             :inferences (keys inferences)
+                             :leaf-nodes leaf-node})))
         ;;There are a lot of firsts here because generically out network could take
         ;;many inputs and produce many outputs.  When we are training classification
         ;;tasks however we know this isn't the case; we have one input and one output
-        inferences (first (vals inferences))
+        inferences (get inferences (first leaf-node))
         data (get data :data)
         labels (get labels :labels)
         inference-answer-patch-pairs (->> (interleave inferences

--- a/suite/src/cortex/suite/classification.clj
+++ b/suite/src/cortex/suite/classification.clj
@@ -185,7 +185,7 @@ observations in each cell instead of just a count."
   (reset! last-network-eval network-eval)
   (let [class-names (get dataset :class-names)
         vec->label #(class-names (loss/max-index (vec %)))
-        _ (when-not (and (contains? inferences :output)
+        _ (when-not (and (map? inferences)
                          (contains? labels :labels)
                          (contains? data :data))
             (throw (ex-info "Classification datasets should have :output :labels and :data."
@@ -195,7 +195,7 @@ observations in each cell instead of just a count."
         ;;There are a lot of firsts here because generically out network could take
         ;;many inputs and produce many outputs.  When we are training classification
         ;;tasks however we know this isn't the case; we have one input and one output
-        inferences (get inferences :output)
+        inferences (first (vals inferences))
         data (get data :data)
         labels (get labels :labels)
         inference-answer-patch-pairs (->> (interleave inferences

--- a/suite/src/cortex/suite/train.clj
+++ b/suite/src/cortex/suite/train.clj
@@ -63,7 +63,10 @@ in initial description.  Else returns the initial description"
         (best-network-function {:inferences (ds/batches->columnsv inferences)
                                 :labels (ds/batches->columnsv cv-output)
                                 :data cv-columnar-input
-                                :loss-fn loss-fn}))))
+                                :loss-fn loss-fn
+                                :leaf-node (->> (get-in network [:layer-graph :edges])
+                                             network/edges->roots-and-leaves
+                                             last)}))))
   true)
 
 
@@ -78,7 +81,7 @@ in initial description.  Else returns the initial description"
                                ((resolve 'think.compute.nn.cuda-backend/create-backend) datatype)
                                (catch Exception e
                                  (println (format "Failed to create cuda backend (%s); will use cpu backend" e))
-                                   (throw e) 
+                                   (throw e)
                                  nil))
                        (cpu-backend/create-cpu-backend datatype)))))
 


### PR DESCRIPTION
@cnuernber: "inferences" does not have the key ":output". The key seems to be the last node-id (like :softmax-1). Created a PR to highlight the issue -- other people using suite will encounter it on 0.4.0 and beyond.