### PR TITLE
[suite/train] Simple loss print.

### DIFF
--- a/cortex/src/cortex/nn/execute.clj
+++ b/cortex/src/cortex/nn/execute.clj
@@ -166,7 +166,7 @@ Returns map of:
           (count buffer-map-seq)))))
 
 
-(defn pprint-executed-loss-fn
+(defn loss-fn->table-str
   [loss-fn]
   (with-out-str
     (pprint/print-table [:type :value :lambda :node-id :parameter]

--- a/cortex/src/cortex/verify/nn/train.clj
+++ b/cortex/src/cortex/verify/nn/train.clj
@@ -175,7 +175,7 @@
                                           (println (format "Loss for epoch %s: %s%s\n\n"
                                                            (get network :epoch-count)
                                                            (apply + (map :value loss-fn))
-                                                           (execute/pprint-executed-loss-fn loss-fn))))
+                                                           (execute/loss-fn->table-str loss-fn))))
                                          entry))
         score (loss/evaluate-softmax results answers)]
     (is (> score 0.6))))

--- a/suite/src/cortex/suite/train.clj
+++ b/suite/src/cortex/suite/train.clj
@@ -37,7 +37,7 @@ in initial description.  Else returns the initial description"
 
 (defn per-epoch-eval-training-network
   [context best-network-atom network-filename initial-description
-   best-network-function cv-columnar-input cv-output
+   best-network-function cv-columnar-input cv-output simple-loss-print?
    {:keys [network inferences]}]
   (let [loss-fn (execute/network->applied-loss-fn
                  context network inferences
@@ -46,10 +46,9 @@ in initial description.  Else returns the initial description"
         current-best-loss (if-let [best-loss (get @best-network-atom :cv-loss)]
                             (when (sequential? best-loss)
                               (apply + (map :value best-loss))))]
-    (println (format "Loss for epoch %s: %s%s\n\n"
-                     (get network :epoch-count)
-                     loss-val
-                     (execute/pprint-executed-loss-fn loss-fn)))
+    (println (format "Loss for epoch %s: %s" (get network :epoch-count) loss-val))
+    (when-not simple-loss-print?
+      (println (execute/loss-fn->table-str loss-fn)))
     (when (or (nil? current-best-loss)
               (< (double loss-val) (double current-best-loss)))
       (println "Saving network")
@@ -78,7 +77,7 @@ in initial description.  Else returns the initial description"
                                ((resolve 'think.compute.nn.cuda-backend/create-backend) datatype)
                                (catch Exception e
                                  (println (format "Failed to create cuda backend (%s); will use cpu backend" e))
-                                   (throw e) 
+                                   (throw e)
                                  nil))
                        (cpu-backend/create-cpu-backend datatype)))))
 
@@ -129,7 +128,8 @@ we continue to train forever.
              network-filestem best-network-fn
              optimiser
              reset-score
-             force-gpu?]
+             force-gpu?
+             simple-loss-print?]
       :or {batch-size 128
            network-filestem default-network-filestem
            optimiser (cortex-opt/adam)
@@ -162,7 +162,7 @@ we continue to train forever.
                                         :infer-batch-type :cross-validation)
           epoch-processor (partial per-epoch-eval-training-network context
                                    best-network-atom network-filename initial-description
-                                   best-network-fn cv-columnar-input cv-labels)]
+                                   best-network-fn cv-columnar-input cv-labels simple-loss-print?)]
       (println "Training network:")
       (network/print-layer-summary (-> network
                                        traverse/auto-bind-io


### PR DESCRIPTION
By passing `:simple-loss-print? true` to train-n, the user can get a one-line loss printout instead of the whole table. This is nice in many cases, including minimizing printout of unit tests that train lots of epochs fast.