### PR TITLE
[cortex/layers - breaking change] Batch normalization layer default a…

### DIFF
--- a/cortex/src/cortex/nn/layers.clj
+++ b/cortex/src/cortex/nn/layers.clj
@@ -377,9 +377,10 @@ https://arxiv.org/pdf/1502.03167v3.pdf.
 ave-factor is the exponential falloff for the running averages of mean and variance
 while epsilon is the stabilization factor for the variance (because we need inverse variance
 and we don't want to divide by zero."
-  [ave-factor & {:keys [epsilon]
-                 :or {epsilon 1e-4}
-                 :as arg-map}]
+  [& {:keys [ave-factor epsilon]
+      :or {ave-factor 0.9
+           epsilon 1e-4}
+      :as arg-map}]
   (when (< (double epsilon) 1e-5)
     (throw (Exception. "batch-normalization minimum epsilon is 1e-5.
 This is for cudnn compatibility.")))

--- a/cortex/src/cortex/verify/nn/gradient.clj
+++ b/cortex/src/cortex/verify/nn/gradient.clj
@@ -99,7 +99,7 @@
         output input]
     (-> (get-gradients context
                        [(layers/input input-size)
-                        (layers/batch-normalization 1.0)]
+                        (layers/batch-normalization :ave-factor 1.0)]
                        input output (loss/mse-loss)
                        1e-4 batch-size)
         check-gradients)))

--- a/cortex/src/cortex/verify/nn/layers.clj
+++ b/cortex/src/cortex/verify/nn/layers.clj
@@ -472,7 +472,7 @@ for that network."
                                                  double-array
                                                  (cu/ensure-gaussian! 5 20)))))
         network (bind-test-network context [(layers/input input-size)
-                                            (layers/batch-normalization 0.8)]
+                                            (layers/batch-normalization :ave-factor 0.8)]
                                    batch-size
                                    {:data input-size
                                     :labels input-size}

--- a/cortex/src/cortex/verify/nn/train.clj
+++ b/cortex/src/cortex/verify/nn/train.clj
@@ -46,7 +46,7 @@
    (layers/local-response-normalization)
    (layers/convolutional 5 0 1 50)
    (layers/max-pooling 2 0 2)
-   (layers/batch-normalization 0.9 :l1-regularization 1e-4)
+   (layers/batch-normalization :l1-regularization 1e-4)
    (layers/linear 500 :l2-max-constraint 4.0)
    (layers/relu :center-loss {:labels {:stream :labels}
                               :alpha 0.9

--- a/cortex/test/clj/cortex/nn/traverse_test.clj
+++ b/cortex/test/clj/cortex/nn/traverse_test.clj
@@ -20,7 +20,7 @@
    (layers/max-pooling 2 0 2)
    (layers/relu)
    (layers/dropout 0.75)
-   (layers/batch-normalization 0.9)
+   (layers/batch-normalization)
    (layers/linear 500) ;;If you use this description put that at 1000
    (layers/relu :id :feature :center-loss {:labels {:stream :labels}
                                            :label-indexes {:stream :labels}

--- a/examples/suite-classification/src/suite_classification/core.clj
+++ b/examples/suite-classification/src/suite_classification/core.clj
@@ -101,7 +101,7 @@
    (layers/relu)
    (layers/convolutional 5 0 1 50)
    (layers/max-pooling 2 0 2)
-   (layers/batch-normalization 0.9)
+   (layers/batch-normalization)
    (layers/linear 1000)
    (layers/relu :center-loss {:labels {:stream :labels}
                               :alpha 0.9

--- a/suite/test/cortex/suite/logistic_test.clj
+++ b/suite/test/cortex/suite/logistic_test.clj
@@ -30,7 +30,7 @@
 
 (def description
   [(layers/input 2)
-   (layers/batch-normalization 0.9)
+   (layers/batch-normalization)
    (layers/linear->logistic 1)])
 
 (deftest logistic-test


### PR DESCRIPTION
…ve-factor.

Before, users were forced to provide an `ave-factor` as the first argument when creating a batch-normalization layer. This argument has a sane default, and named parameters read better and make more sense in this case. So, this change makes the argument optional.