### PR TITLE
Split

### DIFF
--- a/src/cortex/compute/nn/compute_execute.clj
+++ b/src/cortex/compute/nn/compute_execute.clj
@@ -337,7 +337,9 @@
                                       (let [input-buffer (get id->input-buffer-map
                                                               (get map-key input-key))]
                                         (if input-buffer
-                                          [map-key (assoc buffer-entry buffer-type input-buffer)]
+                                          (do
+                                            [map-key (assoc buffer-entry buffer-type
+                                                            input-buffer)])
                                           [map-key buffer-entry]))))
                                (into {}))
         buffer-resolve (partial find-buffers traversal-buffers)]
@@ -379,12 +381,14 @@
 (defn- resolve-node-arguments
   ([network id id->output-map]
    (let [special-graph (-> (network/network->graph network)
-                           (assoc :buffers (get-in network [:compute-binding :parameter-buffers])))
+                           (assoc :buffers (get-in network [:compute-binding
+                                                            :parameter-buffers])))
          stream-map (->> (get-in network [:compute-binding :stream->buffer-map])
                          (map (fn [[k v]]
                                 [k {:buffer v}]))
                          (into {}))
-         retval (graph/resolve-arguments special-graph (graph/get-node special-graph id)
+         retval (graph/resolve-arguments special-graph
+                                         (graph/get-node special-graph id)
                                          stream-map id->output-map)]
      retval))
   ([network id]

--- a/src/cortex/nn/traverse.clj
+++ b/src/cortex/nn/traverse.clj
@@ -192,9 +192,9 @@ There is an optional argument to remove nodes of a particular type from
 the traversal.
 
 Each item in the sequence is a map of:
-{:incoming ()
+{:incoming buffer-map-seq
  :id
- :outgoing ()
+ :outgoing buffer-map-seq
 }"
   [{:keys [layer-graph] :as network}]
   (let [{:keys [input-bindings output-bindings]} (get network :traversal)
@@ -204,42 +204,59 @@ Each item in the sequence is a map of:
                              (map (fn [[k v]]
                                     [k (dissoc v :stream)]))
                              (into {}))]
-    (->> (graph/dfs-seq layer-graph)
-         (reduce (fn [[retval id->buffer-map] id]
-                   (let [node (graph/get-node layer-graph id)
-                         node-buffer (assoc
-                                      (if-let [output-binding (get output-bindings id)]
-                                        (merge {:output-id id}
-                                               output-binding)
-                                        {:id id})
-                                      :dimension (graph/node->output-dimension node))
-                         incoming (concat
-                                   (->> [id]
-                                        (map input-bindings)
-                                        (remove nil?))
-                                   (->> (get child->parent-map id)
-                                        (map (fn [id]
-                                               (get id->buffer-map id)))))
-                         incoming (if (= 1 (count incoming))
-                                    (update (vec incoming) 0
-                                            assoc :dimension (graph/node->input-dimension
-                                                              node))
-                                    (let [dim-map (group-by :id (graph/node->input-dimensions
-                                                                 node))]
-                                      (->> incoming
-                                           (mapv (fn [{:keys [id] :as entry}]
-                                                   (when-not (contains? dim-map id)
-                                                     (throw (ex-info
-                                                             "Failed to find incoming id"
-                                                             {:id id
-                                                              :possible-ids (keys dim-map)})))
-                                                   (assoc entry :dimension
-                                                          (first (dim-map id))))))))]
-                     [(conj retval {:incoming incoming
-                                    :id id
-                                    :outgoing [node-buffer]})
-                      (assoc id->buffer-map id node-buffer)]))
-                 [[] {}])
+    (->>
+     (graph/dfs-seq layer-graph)
+     (reduce
+      (fn [[retval id->buffer-map] id]
+        (let [node (graph/get-node layer-graph id)
+              output-dims (graph/node->output-dimensions node)
+              output-buffers (if (= 1 (count output-dims))
+                               (-> (assoc
+                                    (if-let [output-binding (get output-bindings id)]
+                                      (merge {:output-id id}
+                                             output-binding)
+                                      {:id id})
+                                    :dimension (graph/node->output-dimension node))
+                                   vector)
+                               (->> output-dims
+                                    (map-indexed (fn [idx output-dim]
+                                                   {:id (keyword (str (name id)
+                                                                      "-"
+                                                                      (+ idx 1)))
+                                                    :dimension output-dim}))
+                                    vec))
+              ;;Take the input bindings and the incoming ids and ensure that all buffers
+              ;;have the correct id and have dimensions on them.
+              incoming (concat
+                        (->> [id]
+                             (map input-bindings)
+                             (remove nil?)
+                             (map #(assoc %
+                                          :dimension
+                                          (graph/node->input-dimension node))))
+                        (->> (get child->parent-map id)
+                             ;;Find the parent output dimension that targets this node.
+                             ;;This accounts for the possibility that a parent could have
+                             ;;different sized outputs for different children.
+                             (map (fn [parent-id]
+                                    (let [output-dims (get id->buffer-map parent-id)
+                                          retval (if (= 1 (count output-dims))
+                                                   (first output-dims)
+                                                   (first (filter
+                                                           #(= id (get-in %
+                                                                          [:dimension :id]))
+                                                           output-dims)))]
+                                      (when-not retval
+                                        (throw (ex-info "Failed to find input buffer"
+                                                        {:node node
+                                                         :parent parent-id
+                                                         :parent-output-dims output-dims})))
+                                      retval)))))]
+          [(conj retval {:incoming (vec incoming)
+                         :id id
+                         :outgoing output-buffers})
+           (assoc id->buffer-map id output-buffers)]))
+      [[] {}])
          first)))
 
 
@@ -275,6 +292,10 @@ Each item in the sequence is a map of:
        first
        reverse))
 
+(defn- buffer-desc->map-key
+  [buffer-desc]
+  (select-keys buffer-desc [:id :stream :output-id]))
+
 
 (defn traversal->buffers
   "Traversals initial hold id of incoming nodes.  For the next steps
@@ -283,18 +304,19 @@ the incoming buffer of the next step points to the outgoing buffer of
 the previous step."
   [traversal buffer-map]
   (->> traversal
-       (reduce (fn [[traversal buffer-map] {:keys [incoming id outgoing] :as entry}]
-                 [(conj traversal
-                        {:incoming (flatten
-                                    (map (fn [incoming-data]
-                                           (if-let [id (get incoming-data :id)]
-                                             (get buffer-map id)
-                                             incoming-data))
-                                         incoming))
-                         :id id
-                         :outgoing outgoing})
-                  (assoc buffer-map id outgoing)])
-               [[] buffer-map])))
+       (mapcat #(concat (get % :incoming)
+                        (get % :outgoing)))
+       (concat (vals buffer-map))
+       (group-by buffer-desc->map-key)
+       (map (fn [[buf-key buf-val-seq]]
+              (let [val-map (group-by #(graph/dimensions->size (get % :dimension))
+                                      buf-val-seq)]
+                (when-not (= 1 (count val-map))
+                  (throw (ex-info "Multiple sized buffers detected for key"
+                                  {:buffer-key buf-key
+                                   :buffer-values buf-val-seq})))
+                [buf-key (first buf-val-seq)])))
+       (into {})))
 
 
 (defn- reverse-forward-traversal
@@ -308,34 +330,15 @@ the previous step."
                      :outgoing incoming)))))
 
 
-(defn- buffer-desc->map-key
-  [buffer-desc]
-  (select-keys buffer-desc [:id :stream :output-id]))
-
-
-(defn- forward-traversal->buffer-map
-  [network forward-traversal]
-  (let [layer-graph (get network :layer-graph)]
-    (reduce (fn [buffer-map {:keys [incoming id outgoing]}]
-              (let [node (graph/get-node layer-graph id)]
-                (merge buffer-map
-                       (->> (concat outgoing incoming)
-                            (map (fn [buffer-desc]
-                                   [(buffer-desc->map-key buffer-desc) buffer-desc]))
-                            (into {})))))
-            {}
-            forward-traversal)))
-
-
-(defn- clean-traversal-incoming-outgoing
+(defn clean-traversal-incoming-outgoing
   "Make the incoming and outgoing edges actually valid buffer keys
 which means removing extra information from them."
   [traversal]
-  (map (fn [entry]
-         (-> entry
-             (update :incoming #(map buffer-desc->map-key %))
-             (update :outgoing #(map buffer-desc->map-key %))))
-       traversal))
+  (mapv (fn [entry]
+          (-> entry
+              (update :incoming #(mapv buffer-desc->map-key %))
+              (update :outgoing #(mapv buffer-desc->map-key %))))
+        traversal))
 
 
 (defn- remove-non-trainable
@@ -499,7 +502,7 @@ You can specify a loss here directly or you can specify loss terms around the gr
   (let [network (remove-existing-loss-terms network)
         forward-traversal (->> (create-forward-traversal network)
                                (filter-traversal network :training))
-        [forward-with-buffers buffer-map] (traversal->buffers forward-traversal {})
+        buffer-map (traversal->buffers forward-traversal {})
         backward-pass (if keep-non-trainable?
                         forward-traversal
                         (remove-non-trainable network forward-traversal))
@@ -519,14 +522,12 @@ You can specify a loss here directly or you can specify loss terms around the gr
     (update network
             :traversal
             #(merge %
-                    {:forward (-> forward-with-buffers
+                    {:forward (-> forward-traversal
                                   clean-traversal-incoming-outgoing)
                      :backward (-> backward-pass
-                                   (traversal->buffers buffer-map)
-                                   first
                                    reverse-forward-traversal
                                    clean-traversal-incoming-outgoing)
-                     :buffers (forward-traversal->buffer-map network forward-with-buffers)
+                     :buffers buffer-map
                      :type :training
                      :stream-map (->> (get-in network [:layer-graph :streams])
                                       (map (fn [[k v]]
@@ -541,21 +542,18 @@ You can specify a loss here directly or you can specify loss terms around the gr
   "Similar to network->gradient-descent however in this case we have the option of optimising
   for memory which means we can aggressively reuse buffers *or* optimising for speed in which
   case the result is the forward pass of gradient descent and we expect implementations to have
-  multiple batches in flight simultaneously.  We default to optimising for memory because this
-  avoids OOM situations with large networks."
+  multiple batches in flight simultaneously."
   [{:keys [layer-graph] :as network} stream-map]
   (check-for-io-bindings network)
   (let [network (remove-existing-loss-terms network)
         forward-traversal (->> (create-forward-traversal network)
-                               (filter-traversal network :inference)
-                               (#(traversal->buffers % {}))
-                               first)]
+                               (filter-traversal network :inference))]
     (update network
             :traversal
             #(merge
               %
               {:forward (clean-traversal-incoming-outgoing forward-traversal)
-               :buffers (forward-traversal->buffer-map network forward-traversal)
+               :buffers (traversal->buffers forward-traversal {})
                :type :inference
                :stream-map stream-map}))))
 

--- a/src/cortex/nn/traverse.clj
+++ b/src/cortex/nn/traverse.clj
@@ -198,7 +198,6 @@ Each item in the sequence is a map of:
 }"
   [{:keys [layer-graph] :as network}]
   (let [{:keys [input-bindings output-bindings]} (get network :traversal)
-        ;;Remove all edges that do not participate in the keep node set.
         child->parent-map (graph/child->parent-map layer-graph)
         output-bindings (->> output-bindings
                              (map (fn [[k v]]

--- a/src/cortex/verify/nn/gradient.clj
+++ b/src/cortex/verify/nn/gradient.clj
@@ -158,3 +158,19 @@
                        inputs outputs
                        1e-4 batch-size)
         check-gradients)))
+
+(defn split-gradient
+  [context]
+  (let [batch-size 4
+        input-size 5
+        num-outputs 2
+        inputs [(mapv vec (partition input-size (range (* batch-size input-size))))]
+        outputs (repeat num-outputs (repeat (* input-size batch-size) 1))]
+    (-> (get-gradients context
+                       [(layers/input input-size)
+                        (layers/split :id :test)
+                        (layers/split)
+                        (layers/split :parents [:test])]
+                       inputs outputs
+                       1e-4 batch-size)
+        check-gradients)))

--- a/test/clj/cortex/compute/nn/cuda_gradient_test.clj
+++ b/test/clj/cortex/compute/nn/cuda_gradient_test.clj
@@ -30,3 +30,6 @@
 
 (deftest concat-gradient
   (verify-gradient/concat-gradient (create-context)))
+
+(deftest split-gradient
+  (verify-gradient/split-gradient (create-context)))

--- a/test/clj/cortex/compute/nn/cuda_layers_test.clj
+++ b/test/clj/cortex/compute/nn/cuda_layers_test.clj
@@ -70,3 +70,6 @@
 
 (def-double-float-test concatenate
   (verify-layers/concatenate (create-context)))
+
+(def-double-float-test split
+  (verify-layers/split (create-context)))

--- a/test/clj/cortex/compute/nn/gradient_test.clj
+++ b/test/clj/cortex/compute/nn/gradient_test.clj
@@ -26,3 +26,6 @@
 
 (deftest concat-gradient
   (gradient/concat-gradient (create-context)))
+
+(deftest split-gradient
+  (gradient/split-gradient (create-context)))

--- a/test/clj/cortex/compute/nn/layers_test.clj
+++ b/test/clj/cortex/compute/nn/layers_test.clj
@@ -71,3 +71,6 @@
 
 (def-double-float-test concatenate
   (verify-layers/concatenate (create-context)))
+
+(def-double-float-test split
+  (verify-layers/split (create-context)))

--- a/test/clj/cortex/nn/traverse_test.clj
+++ b/test/clj/cortex/nn/traverse_test.clj
@@ -536,3 +536,50 @@
               :loss {:type :mse-loss},
               :dimension {:channels 1, :height 1, :width 10}}},
             (get train-traversal :buffers))))))
+
+
+(deftest split-traversal
+  (let [network (-> (network/build-network [(layers/input 50)
+                                            (layers/split :id :split)
+                                            (layers/linear 10)
+                                            (layers/linear 20 :parents [:split])])
+                    (traverse/auto-bind-io))
+        stream->size-map {:data 50
+                          :labels-1 10
+                          :labels-2 20}
+
+        train-network (traverse/network->training-traversal network stream->size-map)
+        train-traversal (-> (get train-network :traversal)
+                            realize-traversals)]
+    (is (= [nil nil]
+           (minimal-diff
+            [{:incoming [{:stream :data}],
+              :id :split,
+              :outgoing [{:id :split-1} {:id :split-2}]}
+             {:incoming [{:id :split-1}],
+              :id :linear-1,
+              :outgoing [{:output-id :linear-1}]}
+             {:incoming [{:id :split-2}],
+              :id :linear-2,
+              :outgoing [{:output-id :linear-2}]}]
+            (get train-traversal :forward))))
+    (is (= [nil nil]
+           (minimal-diff
+            {{:stream :data}
+             {:stream :data, :dimension {:channels 1, :height 1, :width 50}},
+             {:id :split-1}
+             {:id :split-1,
+              :dimension {:channels 1, :height 1, :width 50, :id :linear-1}},
+             {:id :split-2}
+             {:id :split-2,
+              :dimension {:channels 1, :height 1, :width 50, :id :linear-2}},
+             {:output-id :linear-1}
+             {:output-id :linear-1,
+              :loss {:type :mse-loss},
+
+              :dimension {:channels 1, :height 1, :width 10}},
+             {:output-id :linear-2}
+             {:output-id :linear-2,
+              :loss {:type :mse-loss},
+              :dimension {:channels 1, :height 1, :width 20}}}
+            (get train-traversal :buffers))))))


### PR DESCRIPTION
1.  Implemented a split layer.  This leaves only a join layer (of which there are two operations, + and * that I *think* are necessary).  
2.  Cleaned up traversal layer a lot.  Not so much that it couldn't use a lot more cleanup.   Less and less impressed with the buffer id system.
3.  Fought a lot with the layer testing system for split and just gave up.  Luckily the gradient testing system worked flawlessly which I guess is more important.  The math is simple so that is it.