### PR TITLE
[layers WIP] an :id in these args can cause the network to fail to bu…

### DIFF
--- a/src/cortex/nn/layers.clj
+++ b/src/cortex/nn/layers.clj
@@ -260,10 +260,10 @@ no change to the input."
 ;; Composites
 
 (defn linear->softmax
-  [num-classes & args]
+  [num-classes & {:keys [] :as args}]
   (vec
-   (concat (apply linear num-classes args)
-           (apply softmax args))))
+   (concat (apply linear num-classes (flatten (seq (dissoc args :id))))
+           (apply softmax (flatten (seq args))))))
 
 
 (defn linear->relu

--- a/src/cortex/nn/layers.clj
+++ b/src/cortex/nn/layers.clj
@@ -203,12 +203,6 @@ If the input contains no channels then you get a scale factor per input paramete
   [(merge-args {:type :logistic} args)])
 
 
-(defn linear->logistic
-  [num-output & args]
-  (concat (apply linear num-output args)
-          (apply logistic args)))
-
-
 (defmethod graph/get-node-metadata :logistic
   [& args]
   (default-layer-metadata))
@@ -217,12 +211,6 @@ If the input contains no channels then you get a scale factor per input paramete
 (defn tanh
   [& args]
   [(merge-args {:type :tanh} args)])
-
-
-(defn linear->tanh
-  [num-output & args]
-  (concat (apply linear num-output args)
-          (apply tanh args)))
 
 
 (defmethod graph/get-node-metadata :tanh
@@ -259,17 +247,42 @@ no change to the input."
 
 ;; Composites
 
+(defn- seq-without-id
+  [coll]
+  (->> coll
+       (reduce (fn [[eax last-elt] elt]
+                 (if (or (= :id elt) (= :id last-elt))
+                   [eax elt]
+                   [(conj eax elt) elt]))
+               [[] nil])
+       (first)
+       (seq)))
+
 (defn linear->softmax
-  [num-classes & {:keys [] :as args}]
+  [num-classes & args]
   (vec
-   (concat (apply linear num-classes (flatten (seq (dissoc args :id))))
-           (apply softmax (flatten (seq args))))))
+   (concat (apply linear num-classes (seq-without-id args))
+           (apply softmax args))))
 
 
 (defn linear->relu
   [num-output & args]
-  (concat (apply linear num-output args)
+  (concat (apply linear num-output (seq-without-id args))
           (apply relu args)))
+
+
+(defn linear->tanh
+  [num-output & args]
+  (concat (apply linear num-output (seq-without-id args))
+          (apply tanh args)))
+
+
+(defn linear->logistic
+  [num-output & args]
+  (concat (apply linear num-output (seq-without-id args))
+          (apply logistic args)))
+
+
 
 
 ;; Convolutional Layers

--- a/test/clj/cortex/nn/network_test.clj
+++ b/test/clj/cortex/nn/network_test.clj
@@ -80,3 +80,25 @@
                  (assoc (clean-output-dims :left)
                         :id :left)])
            (set (graph/node->input-dimensions concat-node))))))
+
+
+(deftest composite-layer-id
+  (let [network (network/linear-network [(layers/input 2 1 1 :id :in)
+                                         (layers/linear->softmax 2 :id :out)])
+        out-node (network/network->node network :out)]
+    (is (= :softmax (:type out-node))))
+
+  (let [network (network/linear-network [(layers/input 2 1 1 :id :in)
+                                         (layers/linear->relu 2 :id :out)])
+        out-node (network/network->node network :out)]
+    (is (= :relu (:type out-node))))
+
+  (let [network (network/linear-network [(layers/input 2 1 1 :id :in)
+                                         (layers/linear->tanh 2 :id :out)])
+        out-node (network/network->node network :out)]
+    (is (= :tanh (:type out-node))))
+
+  (let [network (network/linear-network [(layers/input 2 1 1 :id :in)
+                                         (layers/linear->logistic 2 :id :out)])
+        out-node (network/network->node network :out)]
+    (is (= :logistic (:type out-node)))))


### PR DESCRIPTION
…ild.

I do not like this particular solution; we should find a good one, and apply it uniformly to all the -> layers.

Before this change, the following network cannot be built:
```
(def description
  [(layers/input 2 1 1 :id :pt)
   (layers/linear->relu 128)
   (layers/linear->relu 128)
   (layers/linear->relu 128)
   (layers/linear->softmax 2 :id :label)])
```

Because the final `linear` and `softmax` both get the id `:label` and duplicate ids are not allowed.