### PR TITLE
[nn/execute] Spurious throw in `execute-loss-term`.

### DIFF
--- a/src/cortex/nn/execute.clj
+++ b/src/cortex/nn/execute.clj
@@ -45,15 +45,11 @@ Furthermore infer should be both wrapped in a resource context and completely re
 (defn- execute-loss-term
   "Execute a loss term.  This uses the context to find node and loss parameters."
   [graph loss-term inference-maps dataset-maps]
-  (when-not (= (count inference-maps)
-               (count dataset-maps))
-    (throw (ex-info "Inference and dataset counts differ"
-                    {:inference-count (count inference-maps)
-                     :dataset-count (count dataset-maps)})))
   (* (double (loss/get-loss-lambda loss-term))
-     (/ (->> (map (fn [node-map stream-map]
-                    (loss/loss loss-term (graph/resolve-arguments graph loss-term stream-map node-map)))
-                  inference-maps dataset-maps)
+     (/ (->> (map #(->> (graph/resolve-arguments graph loss-term %1 %2)
+                        (loss/loss loss-term))
+                  dataset-maps
+                  inference-maps)
              (apply +))
         (count inference-maps))))
 

--- a/src/cortex/nn/execute.clj
+++ b/src/cortex/nn/execute.clj
@@ -313,10 +313,9 @@ Furthermore infer should be both wrapped in a resource context and completely re
 (defn train
   "Train.  Returns a tuple of network and optimizer where both the network and optimizer's
 parameters are updated."
-  [network dataset &
-   {:keys [batch-size context optimizer datatype]
-    :or {batch-size 10
-         datatype :float}}]
+  [network dataset & {:keys [batch-size context optimizer datatype]
+                      :or {batch-size 10
+                           datatype :float}}]
   (resource/with-resource-context
     (let [optimizer (or optimizer (adam/adam))
           context (or context (compute-context :datatype datatype))

--- a/test/clj/cortex/compute/nn/cuda_train_test.clj
+++ b/test/clj/cortex/compute/nn/cuda_train_test.clj
@@ -18,9 +18,15 @@
 (def-double-float-test mnist
   (verify-train/train-mnist (create-context)))
 
+(def-double-float-test dataset-batch-size-mismatch
+  (verify-train/dataset-batch-size-mismatch (create-context)))
+
 (comment
+
  (def-double-float-test simple-learning-attenuation
    (verify-train/test-simple-learning-attenuation (create-context)))
 
  (def-double-float-test softmax-channels
-   (verify-train/test-softmax-channels (create-context))))
+   (verify-train/test-softmax-channels (create-context)))
+
+ )

--- a/test/clj/cortex/compute/nn/train_test.clj
+++ b/test/clj/cortex/compute/nn/train_test.clj
@@ -23,3 +23,7 @@
 
 (def-double-float-test mnist
   (verify-train/train-mnist (create-context)))
+
+
+(def-double-float-test dataset-batch-size-mismatch
+  (verify-train/dataset-batch-size-mismatch (create-context)))


### PR DESCRIPTION
These counts matching precisely doesn't really matter. The (indirect) call to `partition` in `train` quantizes the inference-count to be a multiple of the batch-size while leaving the dataset-count alone.

Tests still pass, and I verified this works with a couple of models I've been training that I'd accounted for this outside (by ensuring that my batch size divided my dataset size evenly). With this change they still work without those outside hacks.