### PR TITLE
[cortex/loss-test] Un-comment out this test.

### DIFF
--- a/test/clj/cortex/loss_test.clj
+++ b/test/clj/cortex/loss_test.clj
@@ -34,5 +34,4 @@
         buffer-map {:output 0.0
                     :labels 0.2}
         loss-value (loss/loss mse-loss buffer-map)]
-    (println "TODO: Un-comment this assertion after upgrading core.matrix > 0.57.0.")
-    #_(is (not (Double/isNaN loss-value)))))
+    (is (not (Double/isNaN loss-value)))))


### PR DESCRIPTION
A defect in core.matrix was making this test fail, but that defect is fixed now.