### PR TITLE
[experiment] Classification bug fixes.

### DIFF
--- a/examples/mnist-classification/src/mnist_classification/core.clj
+++ b/examples/mnist-classification/src/mnist_classification/core.clj
@@ -139,16 +139,16 @@
    (let [training-folder (str dataset-folder "training")
          test-folder (str dataset-folder "test")
          [train-ds test-ds] [(-> training-folder
-                                 (experiment-util/create-dataset-from-folder :image-aug-fn (:image-aug-fn argmap))
+                                 (experiment-util/create-dataset-from-folder class-mapping
+                                                                             :image-aug-fn (:image-aug-fn argmap))
                                  (experiment-util/infinite-class-balanced-dataset))
                              (-> test-folder
-                                 (experiment-util/create-dataset-from-folder :image-aug-fn (:image-aug-fn argmap)))]]
+                                 (experiment-util/create-dataset-from-folder class-mapping))]]
      (classification/perform-experiment (initial-description image-size image-size num-classes)
                                         train-ds test-ds
                                         mnist-observation->image
                                         class-mapping
-                                        (merge argmap
-                                               (:image-aug-fn image-aug-pipeline))))))
+                                        argmap))))
 
 
 (defn train-forever-uberjar
@@ -173,7 +173,7 @@
   []
   (ensure-images-on-disk!)
   (let [observation (->> (str dataset-folder "test")
-                         (experiment-util/create-dataset-from-folder)
+                         (experiment-util/create-dataset-from-folder class-mapping)
                          (rand-nth))]
     (i/show (mnist-observation->image (:data observation)))
     {:answer (-> observation :labels util/max-index)
@@ -189,8 +189,8 @@
   "This is an example of how to use cortex to fine tune an existing network."
   []
   (ensure-images-on-disk!)
-  (let [train-ds (experiment-util/create-dataset-from-folder (str dataset-folder "training"))
-        test-ds (experiment-util/create-dataset-from-folder (str dataset-folder "test"))
+  (let [train-ds (experiment-util/create-dataset-from-folder (str dataset-folder "training") class-mapping)
+        test-ds (experiment-util/create-dataset-from-folder (str dataset-folder "test") class-mapping)
         mnist-network (util/read-nippy-file network-filename)
         initial-description (:initial-description mnist-network)
         ;; To figure out at which point you'd like to split the network,

--- a/experiment/src/cortex/experiment/util.clj
+++ b/experiment/src/cortex/experiment/util.clj
@@ -34,26 +34,26 @@
 
 (defn- file->observation
   "Given a file, returns an observation map (an element of a dataset)."
-  [image-aug-fn datatype num-classes ^File file]
-  (let [^String label-idx (-> (re-seq #"(\d)/[^/]+$" (.getPath file)) first last)
-        image (i/load-image file)]
-    {:data (image->observation-data image datatype image-aug-fn)
-     :labels (util/idx->one-hot (Integer. label-idx) num-classes)}))
+  [{:keys [class-name->index]} image-aug-fn datatype ^File file]
+  (try
+    {:data (image->observation-data (i/load-image file) datatype image-aug-fn)
+     :labels (util/idx->one-hot (class-name->index (.. file getParentFile getName))
+                                (count (keys class-name->index)))}
+    (catch Throwable _
+      (println "Problem converting file to observation:" (.getPath file)))))
 
 
 (defn create-dataset-from-folder
-  "Turns a folder of folders of images into a dataset (a sequence of maps)."
-  [folder-name & {:keys [image-aug-fn datatype]
-                  :or {datatype :float}}]
+  "Turns a folder of folders of png images into a dataset (a sequence of maps)."
+  [folder-name class-mapping & {:keys [image-aug-fn datatype]
+                                :or {datatype :float}}]
   (println "Building dataset from folder:" folder-name)
-  (let [f (io/as-file folder-name)
-        num-classes (->> (.listFiles f)
-                         (filter #(.isDirectory ^File %))
-                         (count))]
-    (->> (file-seq f)
-         (filter #(.endsWith (.getName ^File %) "png"))
-         (map (partial file->observation
-                       (and (.contains ^String folder-name "train")
-                            image-aug-fn)
-                       datatype
-                       num-classes)))))
+  (->> folder-name
+       (io/as-file)
+       (file-seq)
+       (filter #(.endsWith (.getName ^File %) "png"))
+       (map (partial file->observation
+                     class-mapping
+                     image-aug-fn
+                     datatype))
+       (remove nil?)))

--- a/src/cortex/util.cljc
+++ b/src/cortex/util.cljc
@@ -71,6 +71,8 @@
   "Given an index and a count `p`, returns a one-hot encoded vector in
   `p`-dimensional space."
   [idx p]
+  (when (or (not idx) (not (< -1 idx p)))
+    (throw (ex-info "Bad idx->one-hot" {:idx idx :p p})))
   (assoc (vec (repeat p 0.0)) idx 1.0))
 
 ;;;; Timing

--- a/test/cljc/cortex/util_test.cljc
+++ b/test/cljc/cortex/util_test.cljc
@@ -168,3 +168,7 @@
 (deftest sprintf-test
   (is (= (with-out-str (sprintf "%(d%n" [[1 -3 5] [-7 3]]))
          (format "[[1 (3) 5] [(7) 3]]%n"))))
+
+(deftest idx->one-hot-test
+  (is (= [1.0 0.0 0.0 0.0] (idx->one-hot 0 4)))
+  (is (thrown? clojure.lang.ExceptionInfo (idx->one-hot nil 4))))


### PR DESCRIPTION
This fixes up a couple of assumptions in the experiment machinery that class names will be numbers, and such (they are in mnist, but not in general). The class-mapping is a better way to handle this.

Also added some error handling and tests to util/idx->one-hot.