### PR TITLE
Trying to get to the bottom of the unit test oddities

### DIFF
--- a/src/cortex/nn/compute_binding.clj
+++ b/src/cortex/nn/compute_binding.clj
@@ -438,6 +438,9 @@
 
 
 (defn output-values
+  "Output the values from the network into a set of buffers.
+Laziness here means the network will do a side-effecty operation into the buffer
+before you are ready."
   [network output-buffers
    & {:keys [max-result-vector-size]
       :or {max-result-vector-size 100}}]
@@ -463,6 +466,7 @@
             ;;One sync for entire buffer set.
             (drv/sync-stream stream)
             (->> buf-seq
+                 ;;Laziness is not your friend here.
                  (mapv (fn [{:keys [host-buffer output-size double-buffers node-id]}]
                          (c-for [idx 0 (< idx batch-size) (inc idx)]
                                 (dtype/copy! host-buffer (long (* idx output-size))
@@ -473,7 +477,7 @@
                                             (vec buffer)
                                             buffer)})
                                double-buffers))))))
-         (apply map merge))))
+         (apply mapv merge))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/cortex/verify/nn/train.clj
+++ b/src/cortex/verify/nn/train.clj
@@ -137,9 +137,9 @@
       ;;functions below is rebuilding the entire cuda context which includes compiling kernels and
       ;;doing cuda init, neither of which is designed to be called more than once a program.
       (let [n-epochs 4
-            training-batch-size 10
+            training-batch-size 20
             running-batch-size 100
-            dataset (take 100 @mnist-training-dataset*)
+            dataset (take 200 @mnist-training-dataset*)
             test-dataset (take 100 @mnist-test-dataset*)
             test-labels (map :label test-dataset)
             network (network/linear-network MNIST-NETWORK)


### PR DESCRIPTION
Intermittent failures only on the cpu branch.  Problems could be in the stream event sync mechanism or in the parallel library or just in one bit of lazy code.