### PR TITLE
Save format that only includes pure java types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-
+## Bugs fixed
+- Only save base java types in file.  This avoids incompatibility issues over time and upgrades [#163](https://github.com/thinktopic/cortex/pull/163)
 
 ## [0.9.7] - 2017-05-03
 ## Bugs fixed

--- a/importers/model-upgrader/README.md
+++ b/importers/model-upgrader/README.md
@@ -1,0 +1,10 @@
+# model-upgrader
+
+A library designed to upgrade cortex models when necessary.
+
+## License
+
+Copyright © 2017 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/importers/model-upgrader/project.clj
+++ b/importers/model-upgrader/project.clj
@@ -1,0 +1,10 @@
+(defproject model-upgrader "0.1.0-SNAPSHOT"
+  :description "Upgrade a cortex model to the most recent version."
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.taoensso/nippy "2.13.0"]
+                 [thinktopic/think.datatype "0.3.10"]
+                 ;;Last version of vectorz library that we saved to the file.
+                 [net.mikera/vectorz-clj "0.45.0"]])

--- a/importers/model-upgrader/src/model_upgrader/core.clj
+++ b/importers/model-upgrader/src/model_upgrader/core.clj
@@ -1,0 +1,78 @@
+(ns model-upgrader.core
+  (:require [taoensso.nippy :as nippy]
+            [clojure.java.io :as io]
+            [clojure.core.matrix.macros :refer [c-for]]
+            [clojure.core.matrix :as m]
+            [think.datatype.core :as dtype]
+            [mikera.vectorz.matrix-api])
+  (:import [java.io ByteArrayOutputStream])
+  (:gen-class))
+
+
+(defn- load-nippy-file
+  [fname]
+  (nippy/thaw (with-open [in-stream (io/input-stream (io/file fname))
+                          out-stream (ByteArrayOutputStream.)]
+                (io/copy in-stream out-stream)
+                (.toByteArray out-stream))))
+
+
+(defn- save-nippy-file
+  [model fname]
+  (with-open [stream (io/output-stream (io/file fname))]
+    (.write stream ^bytes (nippy/freeze model))))
+
+
+(defn- partition-data
+  [shape data]
+  (if (seq shape)
+    (reduce (fn [retval dimension]
+              (->> retval
+                   (partition dimension)
+                   (mapv vec)))
+            data
+            (reverse (drop 1 shape)))
+    (first data)))
+
+(defn- remove-vectorz-from-buffer
+  [buffer]
+  (println buffer)
+  (let [shape (m/shape buffer)
+        ary-size (long (last shape))
+        num-arrays (long (apply * 1 (drop-last shape)))
+        double-array-data (-> (repeatedly num-arrays #(double-array ary-size))
+                              vec)
+        host-buf (m/to-double-array buffer)]
+    (c-for [idx 0 (< idx num-arrays) (inc idx)]
+           (dtype/copy! host-buf (* idx ary-size) (get double-array-data idx) 0 ary-size))
+    (partition-data (drop-last shape) double-array-data)))
+
+
+(defn- remove-vectorz-types-from-model
+  [src-fname dest-fname]
+  (-> (load-nippy-file src-fname)
+      (update-in
+       [:compute-graph :buffers]
+       (fn [buffer-map]
+         (->> buffer-map
+              (map (fn [[k buf-entry]]
+                     [k
+                      ;;We drop any gradients
+                      (update (select-keys buf-entry [:buffer]) :buffer
+                              remove-vectorz-from-buffer)]))
+              (into {}))))
+      (save-nippy-file dest-fname)))
+
+
+(defn- usage
+  []
+  (println "Upgrade a cortex 9.X model version to a 1.0 model version\n
+usage: in-nippy-filename out-nippy-filename")
+  (System/exit 1))
+
+
+(defn -main
+  [& args]
+  (when (< (count args) 2)
+    (usage))
+  (remove-vectorz-types-from-model (first args) (second args)))

--- a/src/cortex/compute/math.clj
+++ b/src/cortex/compute/math.clj
@@ -303,12 +303,14 @@ argument for creating an array storing a batch of data."
 
 (defn- partition-data
   [shape data]
-  (reduce (fn [retval dimension]
-            (->> retval
-                 (partition dimension)
-                 (mapv vec)))
-          data
-          (reverse (drop 1 shape))))
+  (if (seq shape)
+    (reduce (fn [retval dimension]
+              (->> retval
+                   (partition dimension)
+                   (mapv vec)))
+            data
+            (reverse (drop 1 shape)))
+    (first data)))
 
 
 (defn shape
@@ -334,7 +336,8 @@ versions of cortex (meaning only contains java base types)."
            (if file-format?
              (let [ary-size (long (last shape))
                    num-arrays (long (apply * 1 (drop-last shape)))
-                   double-array-data (repeatedly num-arrays #(double-array ary-size))]
+                   double-array-data (-> (repeatedly num-arrays #(double-array ary-size))
+                                         vec)]
                (c-for [idx 0 (< idx num-arrays) (inc idx)]
                       (dtype/copy! host-buf (* idx ary-size) (get double-array-data idx) 0 ary-size))
                (partition-data (drop-last shape) double-array-data))

--- a/src/cortex/compute/math.clj
+++ b/src/cortex/compute/math.clj
@@ -5,6 +5,7 @@ These operations are expected to be provided and uniform across drivers and code
 in here should be 100% portable across different compute drivers."
   (:require [clojure.core.matrix.protocols :as mp]
             [clojure.core.matrix :as m]
+            [clojure.core.matrix.macros :refer [c-for]]
             [cortex.compute.driver :as drv]
             [think.datatype.core :as dtype]
             [think.resource.core :as resource]))
@@ -300,27 +301,49 @@ argument for creating an array storing a batch of data."
   (let [[n-rows n-cols] (batch-shape ary)]
     (with-tensor ary (tensor 1 1 n-rows n-cols))))
 
+(defn- partition-data
+  [shape data]
+  (reduce (fn [retval dimension]
+            (->> retval
+                 (partition dimension)
+                 (mapv vec)))
+          data
+          (reverse (drop 1 shape))))
+
+
+(defn shape
+  [^DeviceArray ary]
+  (if (is-tensor-1d-complete? (.tensor ary))
+    (shape-1d ary)
+    (shape-2d ary)))
+
 
 (defn to-core-matrix
   "Convert a device array to a core-matrix type.  This uses generic code and so if you know your backend
-supports it then there may be a faster way to do this operation."
-  ([stream ^DeviceArray ary shape]
+supports it then there may be a faster way to do this operation.
+:file-format? Save in a form that is slow in terms of core matrix but loadable from files of different
+versions of cortex (meaning only contains java base types)."
+  ([stream ^DeviceArray ary shape & {:keys [file-format?]
+                                     :or {file-format? false}}]
    (let [device (drv/get-device stream)
-         retval (m/new-array :vectorz shape)
-         ^doubles ret-ary (mp/as-double-array retval)
-         elem-count (alength ret-ary)
+         elem-count (dtype/ecount ary)
          host-buf (drv/allocate-host-buffer (drv/get-driver device) elem-count (dtype/get-datatype ary))]
      (drv/copy-device->host stream (.device-buffer ary) 0 host-buf 0 elem-count)
      (drv/sync-stream stream)
-     (dtype/copy! host-buf 0 ret-ary 0 elem-count)
-     (resource/release host-buf)
-     retval))
-  ;;Defaults to a 2d representation
-  ([stream ^DeviceArray ary]
-   (to-core-matrix stream ary
-                   (if (is-tensor-1d-complete? (.tensor ary))
-                     (shape-1d ary)
-                     (shape-2d ary)))))
+     (let [retval
+           (if file-format?
+             (let [ary-size (long (last shape))
+                   num-arrays (long (apply * 1 (drop-last shape)))
+                   double-array-data (repeatedly num-arrays #(double-array ary-size))]
+               (c-for [idx 0 (< idx num-arrays) (inc idx)]
+                      (dtype/copy! host-buf (* idx ary-size) (get double-array-data idx) 0 ary-size))
+               (partition-data (drop-last shape) double-array-data))
+             (let [retval (m/new-array :vectorz shape)
+                   ^doubles ret-ary (mp/as-double-array retval)]
+               (dtype/copy! host-buf 0 ret-ary 0 elem-count)
+               retval))]
+       (resource/release host-buf)
+       retval))))
 
 
 (defn device-array->array

--- a/src/cortex/compute/nn/backend.clj
+++ b/src/cortex/compute/nn/backend.clj
@@ -93,8 +93,8 @@ computelayer/forward,backward."
   (math/assign! (get-stream) dest src))
 
 (defn to-core-matrix
-  [backend ary]
-  (math/to-core-matrix (get-stream) ary))
+  [backend ary & opts]
+  (apply math/to-core-matrix (get-stream) ary (math/shape ary) opts))
 
 (defn device-array->array
   [backend datatype device-ary]

--- a/src/cortex/nn/compute_binding.clj
+++ b/src/cortex/nn/compute_binding.clj
@@ -297,7 +297,7 @@
   (let [backend (backend network)
         core-m (fn [data]
                  (when data
-                   (backend/to-core-matrix backend data)))
+                   (backend/to-core-matrix backend data :save-format? true)))
         ->doubles (fn [host-buffer]
                     (when host-buffer
                       (let [retval (double-array (m/ecount host-buffer))]

--- a/src/cortex/nn/compute_binding.clj
+++ b/src/cortex/nn/compute_binding.clj
@@ -297,7 +297,7 @@
   (let [backend (backend network)
         core-m (fn [data]
                  (when data
-                   (backend/to-core-matrix backend data :save-format? true)))
+                   (backend/to-core-matrix backend data :file-format? true)))
         ->doubles (fn [host-buffer]
                     (when host-buffer
                       (let [retval (double-array (m/ecount host-buffer))]


### PR DESCRIPTION
We were just hit by an upgrade to core matrix that destroyed all old nippy files.  The solution is to avoid saving any library-specific types into the file but still save datastructures that are (barely) core matrix compatible.

To be clear, the upgrade was in the base mikera vectorz java library not in core.matrix.  We had been storing the vectorz types in the network save format.