### PR TITLE
refactored listener function

### DIFF
--- a/experiment/src/cortex/experiment/classification.clj
+++ b/experiment/src/cortex/experiment/classification.clj
@@ -181,7 +181,6 @@
   (let [labels (execute/run new-network test-ds :batch-size batch-size)
         vec->label (vec->label-fn class-mapping)
         old-classification-accuracy (:classification-accuracy old-network)
-        _ (println "old class acc " old-classification-accuracy )
         classification-accuracy (double
                                  (/ (->> (map (fn [label observation]
                                                 (= (vec->label (:labels label))

--- a/experiment/src/cortex/experiment/classification.clj
+++ b/experiment/src/cortex/experiment/classification.clj
@@ -171,12 +171,17 @@
   and new network and decide which is best. Here we calculate
   classification accuracy (a good metric for classification tasks) and
   use that both for reporting and comparing."
-  [batch-size confusion-matrix-atom classification-accuracy-atom observation->img-fn class-mapping
-   ;; TODO: no need for context here
-   context new-network old-network test-ds]
+  [confusion-matrix-atom classification-accuracy-atom observation->img-fn class-mapping
+   network-filename
+   ;; global arguments 
+   {:keys [batch-size context]}  
+   ;per-epoch arguments
+   {:keys [new-network old-network test-ds]}
+   ]
   (let [labels (execute/run new-network test-ds :batch-size batch-size)
         vec->label (vec->label-fn class-mapping)
         old-classification-accuracy (:classification-accuracy old-network)
+        _ (println "old class acc " old-classification-accuracy )
         classification-accuracy (double
                                  (/ (->> (map (fn [label observation]
                                                 (= (vec->label (:labels label))
@@ -188,18 +193,26 @@
                                     (count test-ds)))
         best-network? (or (nil? old-classification-accuracy)
                           (> (double classification-accuracy)
-                             (double old-classification-accuracy)))]
+                             (double old-classification-accuracy)))
+        updated-network (if best-network?
+                          (let [best-network
+                            (assoc new-network 
+                              :classification-accuracy classification-accuracy)]
+                            (reset-confusion-matrix confusion-matrix-atom
+                                                    observation->img-fn
+                                                    class-mapping
+                                                    {:labels labels
+                                                    :test-ds test-ds})
+                            (experiment-train/save-network best-network network-filename))
+                            ;;seems dicey. if not the best-network, 
+                            ;;keeps returning the old network,which will result in the training being 
+                            ;;stuck in a sub-optimal state.
+                            (assoc old-network :epoch-count (get new-network :epoch-count)))]
     (swap! classification-accuracy-atom conj classification-accuracy)
-    (if best-network?
-      (reset-confusion-matrix confusion-matrix-atom
-                              observation->img-fn
-                              class-mapping
-                              {:labels labels
-                               :test-ds test-ds}))
     (println "Classification accuracy:" classification-accuracy)
+    
     {:best-network? best-network?
-     :network (assoc new-network :classification-accuracy classification-accuracy)}))
-
+     :network updated-network}))
 
 (defn- train-forever
   "Train forever. This function never returns."
@@ -208,17 +221,19 @@
       :or {batch-size 128
            confusion-matrix-atom (atom {})
            classification-accuracy-atom (atom {})}}]
-  (let [network (network/linear-network initial-description)]
+  (let [network (network/linear-network initial-description)
+        network-filename (str experiment-train/default-network-filestem ".nippy")]
     (experiment-train/train-n network
                               train-ds test-ds
                               :test-fn (partial test-fn
-                                                batch-size
                                                 confusion-matrix-atom
                                                 classification-accuracy-atom
                                                 observation->image-fn
-                                                class-mapping)
+                                                class-mapping
+                                                network-filename)
                               :batch-size batch-size
-                              :force-gpu? force-gpu?)))
+                              :force-gpu? force-gpu?
+                              )))
 
 
 (defn- display-dataset-and-model

--- a/experiment/src/cortex/experiment/train.clj
+++ b/experiment/src/cortex/experiment/train.clj
@@ -43,8 +43,11 @@
     {:best-network? boolean
      :network (assoc new-network :whatever information-needed-to-compare).}"
   ;; TODO: No need for context here.
-  [simple-loss-print? batch-size context ;;no change per epoch
-   new-network old-network test-ds] ;;change per epoch
+  [simple-loss-print? network-filename
+   ;; global arguments 
+   {:keys [batch-size context]}  
+   ;per-epoch arguments
+   {:keys [new-network old-network test-ds]} ] 
   (let [batch-size (long batch-size)
         labels (execute/run new-network test-ds
                  :batch-size batch-size
@@ -58,22 +61,22 @@
                               (apply + (map :value best-loss))))
         best-network? (or (nil? current-best-loss)
                           (< (double loss-val)
-                             (double current-best-loss)))]
+                             (double current-best-loss)))
+        updated-network (assoc new-network :cv-loss loss-fn)]
+    (println " saving current network iteration ")
+    (save-network updated-network network-filename)
+    
     (println (format "Loss for epoch %s: %s" (get new-network :epoch-count) loss-val))
     (when-not simple-loss-print?
       (println (loss/loss-fn->table-str loss-fn)))
     {:best-network? best-network?
-     :network (assoc new-network :cv-loss loss-fn)}))
-
+     :network updated-network}))
 
 (defn- per-epoch-fn
-  [test-network-fn network-filename context ;;these don't change per epoch
-    new-network old-network test-ds] ;;these might
-  (let [test-results (test-network-fn context new-network old-network test-ds)
-        {:keys [best-network? network]} test-results]
-    (if best-network?
-      (save-network network network-filename)
-      (assoc old-network :epoch-count (get new-network :epoch-count)))))
+  [test-network-fn training-context epoch-args] 
+  (let [test-results (test-network-fn training-context epoch-args)
+        {:keys [network]} test-results]
+    network))
 
 
 (defn backup-trained-network
@@ -113,15 +116,18 @@
          retval)))
     (create-n-callable-fn item epoch-count)))
 
-
 (defn- recur-train-network
   [network train-ds-fn test-ds-fn optimizer train-fn epoch-eval-fn]
+  ;[{:keys [network train-ds-fn test-ds-fn optimizer train-fn epoch-eval-fn] :as recur-args}]
   (let [train-data (train-ds-fn)
         test-data (test-ds-fn)
         old-network network]
     (when (and train-data test-data)
       (let [{:keys [network optimizer]} (train-fn network train-data optimizer)
-            network (epoch-eval-fn (update network :epoch-count inc) old-network test-data)]
+            epoch-args {:new-network (update network :epoch-count inc)
+                        :old-network old-network :train-ds train-data
+                        :test-ds test-data}
+            network (epoch-eval-fn epoch-args)]
         (cons network
               (lazy-seq
                (recur-train-network network train-ds-fn test-ds-fn
@@ -142,9 +148,9 @@
   Note, we have to have enough memory to store the cross-validation dataset
   in memory while training.
 
-  Every epoch a test function is called with these arguments:
+  Every epoch a test function is called with these 2 map arguments:
 
-  (test-fn context new-network old-network test-ds)
+  (test-fn global-context epoch-context)
 
   It must return a map containing at least:
     {:best-network? true if this is the best network
@@ -189,9 +195,11 @@
                                      :batch-size batch-size
                                      :optimizer %3
                                      :context context)
+            training-context {:batch-size batch-size :context context}
             test-fn  (or test-fn
-                         (partial default-network-test-fn simple-loss-print? batch-size))
-            epoch-eval-fn (partial per-epoch-fn test-fn network-filename context)]
+                         (partial default-network-test-fn simple-loss-print? 
+                                  network-filename))
+            epoch-eval-fn (partial per-epoch-fn test-fn training-context)]
         (println "Training network:")
         (network/print-layer-summary network (traverse/training-traversal network))
         (->> (recur-train-network network train-ds-fn test-ds-fn optimizer train-fn epoch-eval-fn)


### PR DESCRIPTION
A couple of changes to the listener function which is run on every test epoch:

- Reduces the number of arguments, now has 1 map for global context and another for per-epoch context
- train dataset is also passed to the listener function to evaluate metrics on training set.

I felt that saving the network is best implemented by the listener function, since the requirements may differ. In some situations, each network iteration needs to be saved and in others, the best current network needs to be saved.
Refactored the code to save the network within the listener function.  
