### PR TITLE
Add orthogonal weight initialization

### DIFF
--- a/src/cortex/nn/layers.clj
+++ b/src/cortex/nn/layers.clj
@@ -52,6 +52,11 @@ constructors are all variable args with the extra arguments expected to be
   (buf-init/initialize-buffer {:type :relu
                                :shape shape}))
 
+(defmethod graph/initialize-graph-parameter-buffer :orthogonal
+  [graph node argument shape initialization]
+  (buf-init/initialize-buffer {:type :orthogonal
+                               :shape shape}))
+
 (defmethod graph/initialize-graph-parameter-buffer :xavier
   [graph node argument shape initialization]
   (buf-init/initialize-buffer {:type :xavier

--- a/test/clj/cortex/nn/network_test.clj
+++ b/test/clj/cortex/nn/network_test.clj
@@ -62,7 +62,7 @@
 
 
 (deftest specify-weight-initialization
-  (doseq [weight-initialization-type [:relu :xavier :bengio-glorot]]
+  (doseq [weight-initialization-type [:relu :xavier :bengio-glorot :orthogonal]]
     (let [built-network (network/linear-network [(layers/input 20 20 3 :id :data)
                                                  (layers/convolutional 2 0 1 2 :weights {:initialization {:type weight-initialization-type}})])]
       (is (= weight-initialization-type


### PR DESCRIPTION
Added option to specify weight initialization by random orthogonal vectors instead of just random vectors.  To use, add ":weights {:initialization {:type :orthogonal}}" to any layer.

I expected this to improve training in the early epochs, but after many configurations on cifar-10 data, I did not find it to perform better than He-normal initialization.  Maybe someone else will find it a useful option.