### PR TITLE
Support for viewing weights in Tensorboard

### DIFF
--- a/examples/mnist-classification/src/mnist_classification/core.clj
+++ b/examples/mnist-classification/src/mnist_classification/core.clj
@@ -61,7 +61,6 @@
                                       (+ 0.5 (m/mget ds-data y x)))))))
     (image/array-> retval data-bytes)))
 
-
 (defn- save-image!
   "Save a dataset image to disk."
   [output-dir [idx {:keys [data label]}]]
@@ -87,9 +86,7 @@
 (defonce test-dataset
   (timed-get-dataset mnist/test-dataset "mnist test"))
 
-
 (def dataset-folder "mnist/")
-
 
 (defonce ensure-images-on-disk!
   (memoize
@@ -101,7 +98,6 @@
                  (map-indexed vector test-dataset)))
      :done)))
 
-
 (defn- image-aug-pipeline
   "Uses think.image augmentation to vary training inputs."
   [image]
@@ -112,13 +108,11 @@
                           false)
         (image-aug/inject-noise (* 0.25 (rand))))))
 
-
 (defn- mnist-observation->image
   "Creates a BufferedImage suitable for web display from the raw data
   that the net expects."
   [observation]
   (patch/patch->image observation image-size))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; The classification experiment system needs a way to go back and forth from
@@ -126,7 +120,6 @@
 (def class-mapping
   {:class-name->index (zipmap (map str (range 10)) (range))
    :index->class-name (zipmap (range) (map str (range 10)))})
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main entry point. In general, a classification experiment trains a net
@@ -143,20 +136,48 @@
                                                                              :image-aug-fn (:image-aug-fn argmap))
                                  (experiment-util/infinite-class-balanced-dataset))
                              (-> test-folder
-                                 (experiment-util/create-dataset-from-folder class-mapping))]]
-     (classification/perform-experiment (initial-description image-size image-size num-classes)
-                                        train-ds test-ds
-                                        mnist-observation->image
-                                        class-mapping
-                                        argmap))))
+                                 (experiment-util/create-dataset-from-folder class-mapping))]
+         ;listener (classification/create-listener mnist-observation->image
+         ;                                         class-mapping
+         ;                                         argmap)
+         tboardlistener (classification/create-tensorboard-listener 
+                          {:file-path "/tmp/tflogs/run1.tfevents.out"})]
+     (classification/perform-experiment2
+      (initial-description image-size image-size num-classes)
+      train-ds test-ds tboardlistener))))
 
+(comment
+   (ensure-images-on-disk!)
+   (def training-folder (str dataset-folder "training"))
+   (def test-folder (str dataset-folder "test"))
+   (def k [(-> training-folder
+                                 (experiment-util/create-dataset-from-folder class-mapping)
+                                 (experiment-util/infinite-class-balanced-dataset))
+                             (-> test-folder
+                                 (experiment-util/create-dataset-from-folder class-mapping))])
+
+  (def  train-ds  (first k))
+  (def  test-ds (second k))
+  (def tboardlistener (classification/create-tensorboard-listener 
+                          {:file-path "/tmp/tflogs/run1.tfevents.out"}))
+  (def eval-fn (tboardlistener
+      (initial-description image-size image-size num-classes)
+      train-ds test-ds))
+  (try
+  (let [network (network/linear-network initial-description)]
+    (train/train-n network train-ds test-ds
+                              :test-fn eval-fn
+                              :epoch-count 10
+                              :force-gpu? false))
+  (catch Exception e
+    (clojure.stacktrace/print-stack-trace e)))  
+  )
 
 (defn train-forever-uberjar
   ([] (train-forever-uberjar {}))
   ([argmap]
    (println "Training forever from uberjar.")
    (train-forever argmap)))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Once a net is trained (and the trained model is saved to a nippy file), it
@@ -166,7 +187,6 @@
 ;; simpler, since `cortex` has many fewer dependencies than `experiment.`
 (def network-filename
   (str train/default-network-filestem ".nippy"))
-
 
 (defn label-one
   "Take an arbitrary test image and label it."
@@ -181,7 +201,6 @@
                  (first)
                  (:labels)
                  (util/max-index))}))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Advanced techniques

--- a/examples/mnist-classification/src/mnist_classification/main.clj
+++ b/examples/mnist-classification/src/mnist_classification/main.clj
@@ -10,6 +10,9 @@
    [ "-l" nil
     :long-opt "--live-updates"
     :id :live-updates?
+    :default false]
+   ["-t" "--tensorboard-output value" "Output metrics to tensorboard"
+    :id :tensorboard-output 
     :default false]])
 
 (defn -main

--- a/experiment/project.clj
+++ b/experiment/project.clj
@@ -3,7 +3,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [thinktopic/cortex "0.9.9-SNAPSHOT"]
                  [thinktopic/think.image "0.4.10"]
-                 [org.shark8me/tfevent-sink "0.1.2"]
+                 [org.shark8me/tfevent-sink "0.1.3"]
                  ;;Default way of displaying anything is a web page.
                  ;;Because if you want to train on aws (which you should)
                  ;;you need to get simple servers up and running easily.

--- a/experiment/src/cortex/experiment/classification.clj
+++ b/experiment/src/cortex/experiment/classification.clj
@@ -3,6 +3,7 @@
             [clojure.core.matrix :as m]
             [think.image.patch :as patch]
             [think.gate.core :as gate]
+            [tfevent-sink.event-io :as eio]
             [cortex.nn.network :as network]
             [cortex.nn.execute :as execute]
             [cortex.experiment.train :as experiment-train]
@@ -11,12 +12,10 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-
 (defn- vec->label-fn
   [{:keys [index->class-name]}]
   (fn [label-vec]
     (get index->class-name (util/max-index label-vec))))
-
 
 (defn- network-eval->rich-confusion-matrix
   "A rich confusion matrix is a confusion matrix with the list of
@@ -26,8 +25,8 @@
         vec->label (vec->label-fn class-mapping)
         guess-answer-patch-triplets (map (fn [label {:keys [labels data]}]
                                            [(:labels label) labels data])
-                                          labels
-                                          test-ds)
+                                         labels
+                                         test-ds)
         initial-row (zipmap class-names (repeat {:inferences []
                                                  :observations []}))
         initial-confusion-matrix (zipmap class-names (repeat initial-row))]
@@ -40,7 +39,6 @@
                                  :observations (conj observations patch)})))
                  initial-confusion-matrix))))
 
-
 (defn- rich-confusion-matrix->network-confusion-matrix
   [rich-confusion-matrix observation->img-fn class-mapping]
   (let [class-names (vec (sort (keys (:class-name->index class-mapping))))]
@@ -51,7 +49,7 @@
                                    (get-in rich-confusion-matrix [row-name col-name])
                                    inference-obs-pairs (->> (interleave (map m/emax inferences)
                                                                         observations)
-                                                            (partition 2 )
+                                                            (partition 2)
                                                             (sort-by first >))
                                    num-pairs (count inference-obs-pairs)
                                    detailed-pairs (take 100 inference-obs-pairs)]
@@ -60,7 +58,6 @@
                                 :images (map observation->img-fn (map second detailed-pairs))}))
                            class-names))
                    class-names)}))
-
 
 (defn- reset-confusion-matrix
   [confusion-matrix-atom observation->img-fn class-mapping network-eval]
@@ -74,24 +71,20 @@
              class-mapping))))
   nil)
 
-
 (defn- network-confusion-matrix->simple-confusion-matrix
   [{:keys [matrix] :as network-confusion-matrix}]
   (update-in network-confusion-matrix [:matrix]
              (fn [matrix] (mapv #(mapv :count %) matrix))))
-
 
 (defn- get-confusion-matrix
   [confusion-matrix-atom & args]
   (network-confusion-matrix->simple-confusion-matrix
    @confusion-matrix-atom))
 
-
 (defn- get-confusion-detail
   [confusion-matrix-atom {:keys [row col] :as params}]
   (->> (get-in @confusion-matrix-atom [:matrix row col])
        :inferences))
-
 
 (defn- get-confusion-image
   [confusion-matrix-atom params]
@@ -103,7 +96,6 @@
                                      (into {}))]
     (nth (get-in @confusion-matrix-atom [:matrix row col :images])
          index)))
-
 
 (defn- reset-dataset-display!
   [dataset-display-atom train-ds test-ds observation->img-fn class-mapping]
@@ -133,7 +125,6 @@
                                                ds)})}}))
     nil))
 
-
 (defn- get-dataset-data
   [dataset-display-atom & args]
   (update-in @dataset-display-atom [:dataset]
@@ -142,18 +133,15 @@
                       [k (dissoc v :images)])
                     dataset-map))))
 
-
 (defn- get-dataset-image
   [dataset-display-atom {:keys [batch-type index]}]
   (nth (get-in @dataset-display-atom
                [:dataset (edn/read-string batch-type) :images])
        (edn/read-string index)))
 
-
 (defn- get-accuracy-data
   [classification-accuracy-atom & args]
   @classification-accuracy-atom)
-
 
 (defn- routing-map
   [confusion-matrix-atom classification-accuracy-atom dataset-display-atom]
@@ -163,7 +151,6 @@
    "dataset-data" (partial get-dataset-data dataset-display-atom)
    "dataset-image" (partial get-dataset-image dataset-display-atom)
    "accuracy-data" (partial get-accuracy-data classification-accuracy-atom)})
-
 
 (defn- test-fn
   "The `experiment` training system supports passing in a `test-fn`
@@ -192,45 +179,34 @@
                              (double old-classification-accuracy)))
         updated-network (if best-network?
                           (let [best-network
-                            (assoc new-network
-                              :classification-accuracy classification-accuracy)]
+                                (assoc new-network
+                                       :classification-accuracy classification-accuracy)]
                             (reset-confusion-matrix confusion-matrix-atom
                                                     observation->img-fn
                                                     class-mapping
                                                     {:labels labels
-                                                    :test-ds test-ds})
+                                                     :test-ds test-ds})
                             (experiment-train/save-network best-network network-filename))
                             ;;seems dicey. if not the best-network, 
                             ;;keeps returning the old network,which will result in the training being 
                             ;;stuck in a sub-optimal state.
-                            (assoc old-network :epoch-count (get new-network :epoch-count)))]
+                          (assoc old-network :epoch-count (get new-network :epoch-count)))]
     (swap! classification-accuracy-atom conj classification-accuracy)
     (println "Classification accuracy:" classification-accuracy)
-    
+
     {:best-network? best-network?
      :network updated-network}))
 
 (defn- train-forever
   "Train forever. This function never returns."
-  [initial-description train-ds test-ds observation->image-fn class-mapping
-   & {:keys [batch-size confusion-matrix-atom classification-accuracy-atom force-gpu?]
-      :or {batch-size 128
-           confusion-matrix-atom (atom {})
-           classification-accuracy-atom (atom {})}}]
-  (let [network (network/linear-network initial-description)
-        network-filename (str experiment-train/default-network-filestem ".nippy")]
+  [initial-description train-ds test-ds
+   {:keys [batch-size force-gpu? eval-fn] :or {batch-size 128}}]
+  (let [network (network/linear-network initial-description)]
     (experiment-train/train-n network
                               train-ds test-ds
-                              :test-fn (partial test-fn
-                                                confusion-matrix-atom
-                                                classification-accuracy-atom
-                                                observation->image-fn
-                                                class-mapping
-                                                network-filename)
+                              :test-fn eval-fn
                               :batch-size batch-size
-                              :force-gpu? force-gpu?
-                              )))
-
+                              :force-gpu? force-gpu?)))
 
 (defn- display-dataset-and-model
   "Starts the web server that gives real-time training updates."
@@ -252,32 +228,83 @@
     [confusion-matrix-atom
      classification-accuracy-atom]))
 
+(defn create-listener
+  "initializes any prerequisites for listening functions, and returns a listener
+  function. Arguments:
+  - observation->image-fn: A function that can take observation data and return png data for web display.
+    - class-mapping: A map with two entries
+      - `:class-name->index` a map from class name strings to softmax indexes
+      - `:index->class-name` a map from softmax indexes to class name strings
+   Trains the net indefinitely on the provided training data, evaluating against the test data, and gives live updates on a local webserver hosted at http://localhost:8091. 
+  "  
+  [observation->image-fn class-mapping argmap]
+  (fn [initial-description train-ds test-ds]
+    (let [network (network/linear-network initial-description)
+          network-filename (str experiment-train/default-network-filestem ".nippy")
+          [confusion-matrix-atom classification-accuracy-atom]
+          (display-dataset-and-model train-ds test-ds
+                                     observation->image-fn
+                                     class-mapping
+                                     (:live-updates? argmap))]
+      (partial test-fn
+               confusion-matrix-atom
+               classification-accuracy-atom
+               observation->image-fn
+               class-mapping
+               network-filename))))
+
+(defn log-weights
+  "Given a network, writes all the weights from different
+  layers to the tensorboard event file  "
+  [network]
+  (let [buf (-> network :compute-graph :buffers)]
+    (mapv (fn [[k v]]
+            (eio/make-event (str "buffers/" (name k))
+                            (:buffer v))) buf)))
+
+(defn tensorboard-log
+  "Given the context, old network, the new network and a test dataset,
+  return a map with the updated network.
+  As a side-effect, stream the train/test loss as well as all buffers 
+  as tensorboard events, appended to the file-path argument"
+  [file-path
+   {:keys [batch-size context]}
+   {:keys [new-network old-network test-ds train-ds]}] ;;change per epoch
+  (let [batch-size (long batch-size)
+        get-label (fn [dset] (execute/run new-network dset
+                                          :batch-size batch-size
+                                          :loss-outputs? true
+                                          :context context))
+        labels (get-label test-ds)
+        loss-on (fn [dset] (execute/execute-loss-fn new-network labels dset))
+        cv-loss (loss-on test-ds)
+        test-loss (apply + (map :value cv-loss))
+        train-loss (apply + (map :value (loss-on train-ds)))
+        ;;log train and test loss
+        evs (mapv eio/make-event
+                  (mapv (partial str "metrics/")
+                        ["train-loss" "test-loss"])
+                  [train-loss test-loss])
+        evs (into evs (log-weights new-network))
+        _ (eio/append-events file-path evs)]
+    {:network (assoc new-network :cv-loss cv-loss)}))
+
+(defn create-tensorboard-listener
+  "initializes any prerequisites for listening functions, and returns a listener
+  function. Takes a file-path argument where the events are logged to. "
+  [{:keys [file-path]}]
+  (fn [initial-description train-ds test-ds]
+    (do
+      (println "create-tensorboard-listener ")
+      (eio/create-event-stream file-path)
+      (partial tensorboard-log file-path))))
 
 (defn perform-experiment
   "Main entry point:
     - initial-description: A cortex nerual net description to train.
     - train-ds: A dataset (sequence of maps) with keys `:data`, `:labels`, used for training.
     - test-ds: A dataset (sequence of maps) with keys `:data`, `:labels`, used for testing.
-    - observation->image-fn: A function that can take observation data and return png data for web display.
-    - class-mapping: A map with two entries
-      - `:class-name->index` a map from class name strings to softmax indexes
-      - `:index->class-name` a map from softmax indexes to class name strings
-   Trains the net indefinitely on the provided training data, evaluating against the test data, and gives live updates on a local webserver hosted at http://localhost:8091."
-  ([initial-description train-ds test-ds observation->image-fn class-mapping]
-   (perform-experiment initial-description train-ds test-ds observation->image-fn class-mapping {}))
-  ([initial-description train-ds test-ds observation->image-fn class-mapping argmap]
-   (let [[confusion-matrix-atom
-          classification-accuracy-atom]
-         (display-dataset-and-model train-ds test-ds
-                                    observation->image-fn
-                                    class-mapping
-                                    (:live-updates? argmap))]
-     (apply train-forever
-            initial-description
-            train-ds test-ds
-            observation->image-fn
-            class-mapping
-            (->> (assoc argmap :confusion-matrix-atom confusion-matrix-atom
-                        :classification-accuracy-atom classification-accuracy-atom)
-                 (seq)
-                 (apply concat))))))
+ " ([initial-description train-ds test-ds listener]
+   (let [eval-fn (listener initial-description train-ds test-ds)]
+     (train-forever initial-description train-ds test-ds
+                     {:eval-fn eval-fn}))))


### PR DESCRIPTION
Hi all,

I've added support to view the weights of layers using tensorboard's histograms and distributions. 
The changes in this PR 

- Using [tfevent-sink](https://github.com/shark8me/tfevent-sink) to write both scalars (such as accuracy or loss) and buffers/weights to a Tensorflow Event Record format log file.
- Updated the examples/mnist-classification to accept generic listeners
- capability to test tensorflow outputs using a "-t logfile" argument to the "lein run" command. With no arguments, the existing listener is used.

I would like to hear feedback about the listener API. I refactored the existing API a bit to create listeners may not be image-focused and could accept any necessary arguments. 

![tf buffer1](https://user-images.githubusercontent.com/89076/27000085-f54741ba-4ddb-11e7-8229-34951f6f3193.png)
![tf buffers 2](https://user-images.githubusercontent.com/89076/27000084-f543f280-4ddb-11e7-814b-0897e4e0fba3.png)

