### PR TITLE
[gpu] Support writing out errors to a file when we fallback to cpu su…

### DIFF
--- a/test/clj/cortex/compute/nn/train_test.clj
+++ b/test/clj/cortex/compute/nn/train_test.clj
@@ -16,6 +16,9 @@
   (execute/compute-context :backend :cpu
                            :datatype test-utils/*datatype*))
 
+;; Test creating a context which falls back to CPU after trying GPU first (default behavior)
+(def-double-float-test corn-fallback
+  (verify-train/test-corn (execute/compute-context :datatype test-utils/*datatype*)))
 
 (def-double-float-test corn
   (verify-train/test-corn (create-context)))


### PR DESCRIPTION
This branch will write out errors as they occur when loading the cuda backend. Note that this only occurs when falling back (i.e. if you specify cpu this doesn't happen, if you specify gpu and it works this doesn't happen).

Hopefully this can give us more insight into various failure paths for getting GPU backend to load.