### PR TITLE
Add function to make infinite datasets for regression and classification

### DIFF
--- a/experiment/src/cortex/experiment/util.clj
+++ b/experiment/src/cortex/experiment/util.clj
@@ -6,6 +6,17 @@
   (:import [java.io File]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; General training utils
+(defn infinite-dataset
+  "Given a finite dataset, generate an infinite sequence of maps partitioned
+  by :epoch-size"
+  [map-seq & {:keys [epoch-size]
+              :or {epoch-size 1024}}]
+  (->> (repeatedly #(shuffle map-seq))
+       (mapcat identity)
+       (partition epoch-size)))
+
+
 ;; Classification dataset utils
 (defn infinite-class-balanced-dataset
   "Given a dataset, returns an infinite sequence of maps perfectly

--- a/experiment/test/cortex/experiment/util_test.clj
+++ b/experiment/test/cortex/experiment/util_test.clj
@@ -1,0 +1,9 @@
+(ns cortex.experiment.util-test
+  (:require [clojure.test :refer :all]
+            [cortex.experiment.util :as util]))
+
+(deftest infinite-dataset-test
+  (let [ds [{:a 1 :b 2} {:a 3 :b 4} {:a 5 :b 6}]
+        inf-ds (util/infinite-dataset ds)]
+    (is (< (count (take 10 ds)) 10))
+    (is (= (count (take 10 inf-ds)) 10))))


### PR DESCRIPTION
This adds a general function in experiment/util.clj to make datasets infinite for the train-n function, which can be used for both regression and classification. You can't exactly rewrite infinite-class-balanced-dataset based on this function directly (you would have to refactor common code into a separate function, and it's just two lines so I'm not sure it's worth it). 