### PR TITLE
Data encoding

### DIFF
--- a/experiment/src/cortex/experiment/util.clj
+++ b/experiment/src/cortex/experiment/util.clj
@@ -26,7 +26,7 @@
   "Given a dataset and a list of categorical features, returns a new dataset with these
   features encoded into one-hot indicators
   E.g. (one-hot-encoding [{:a :left} {:a :right} {:a :top}] [:a])
-         => [{:a_0 1 :a_1 0 :a_2 0} {:a_0 0 :a_1 1 :a_2 0} {:a_0: 0 :a_1 0 :a_2 1}]"
+         => [{:a_0 1 :a_1 0 :a_2 0} {:a_0 0 :a_1 1 :a_2 0} {:a_0 0 :a_1 0 :a_2 1}]"
   [dataset features]
   (reduce (fn [mapseq key]
             (let [classes (set (map key mapseq))

--- a/experiment/src/cortex/experiment/util.clj
+++ b/experiment/src/cortex/experiment/util.clj
@@ -6,6 +6,39 @@
   (:import [java.io File]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data encoding utils
+
+(defn label->one-hot
+  "Given a vector of class-names and a label, return a one-hot vector based on
+  the position in class-names.
+  E.g.  (label->vec [:a :b :c :d] :b) => [0 1 0 0]"
+  [class-names label]
+  (let [num-classes (count class-names)
+        src-vec (vec (repeat num-classes 0))
+        label-idx (.indexOf class-names label)]
+    (when (= -1 label-idx)
+      (throw (ex-info "Label not in classes for label->one-hot"
+                      {:class-names class-names :label label})))
+    (assoc src-vec label-idx 1)))
+
+
+(defn one-hot-encoding
+  "Given a dataset and a list of categorical features, returns a new dataset with these
+  features encoded into one-hot indicators
+  E.g. (one-hot-encoding [{:a :left} {:a :right} {:a :top}] [:a])
+         => [{:a_0 1 :a_1 0 :a_2 0} {:a_0 0 :a_1 1 :a_2 0} {:a_0: 0 :a_1 0 :a_2 1}]"
+  [dataset features]
+  (reduce (fn [mapseq key]
+            (let [classes (set (map key mapseq))
+                  new-keys (for [i (range (count classes))]
+                             (keyword (str (name key) "_" i)))] ; a_0, a_1, a_2, etc.
+              (map (fn [elem] (->> (label->one-hot (vec classes) (key elem))
+                                   (zipmap new-keys)
+                                   (merge (dissoc elem key))))
+                   mapseq)))
+          dataset features))
+
+
 ;; General training utils
 (defn infinite-dataset
   "Given a finite dataset, generate an infinite sequence of maps partitioned
@@ -30,7 +63,6 @@
                    (mapcat identity))))
        (apply interleave)
        (partition epoch-size)))
-
 
 
 (defn- image->observation-data

--- a/experiment/test/cortex/experiment/util_test.clj
+++ b/experiment/test/cortex/experiment/util_test.clj
@@ -7,3 +7,10 @@
         inf-ds (util/infinite-dataset ds)]
     (is (< (count (take 10 ds)) 10))
     (is (= (count (take 10 inf-ds)) 10))))
+
+(deftest one-hot-encoding-test
+  (let [ds [{:a :left} {:a :middle} {:a :top} {:a :left}]
+        encoded-ds (util/one-hot-encoding ds [:a])]
+    (is (= (count ds) (count encoded-ds)))
+    (is (= 3 (count (first encoded-ds))))
+    (is (= (first encoded-ds) (last encoded-ds)))))

--- a/experiment/test/cortex/experiment/util_test.clj
+++ b/experiment/test/cortex/experiment/util_test.clj
@@ -9,8 +9,17 @@
     (is (= (count (take 10 inf-ds)) 10))))
 
 (deftest one-hot-encoding-test
-  (let [ds [{:a :left} {:a :middle} {:a :top} {:a :left}]
-        encoded-ds (util/one-hot-encoding ds [:a])]
-    (is (= (count ds) (count encoded-ds)))
-    (is (= 3 (count (first encoded-ds))))
-    (is (= (first encoded-ds) (last encoded-ds)))))
+  (let [ds [{:a "left"} {:a "middle"} {:a "right"}]
+        encoded-ds (util/one-hot-encoding ds [:a])
+        ;; reverse ("decode") the encoding into key
+        decoded-ds-str (util/reverse-one-hot encoded-ds [:a]
+                                             :as-string? true)
+        decoded-ds-symbol (util/reverse-one-hot encoded-ds [:a]
+                                                :as-string? false)]
+    (is (= '({:a_left 1, :a_middle 0, :a_right 0}
+             {:a_left 0, :a_middle 1, :a_right 0}
+             {:a_left 0, :a_middle 0, :a_right 1})
+           encoded-ds))
+    (is (= ds decoded-ds-str))
+    (is (= [{:a :left} {:a :middle} {:a :right}]
+           decoded-ds-symbol))))


### PR DESCRIPTION
Introduces a high-level data preprocessing function called "one-hot-encoding," which takes a dataset and a list of categorical features (i.e. data that takes on discrete values that are not numeric in nature, and as such cannot be fed into an ML algorithm) and performs one-hot encoding of the data. Modeled off of https://pandas.pydata.org/pandas-docs/stable/generated/pandas.get_dummies.html. Should be useful for all sorts of non-image datasets.  