### PR TITLE
Update to clojure 1.9

### DIFF
--- a/examples/catsdogs-classification/project.clj
+++ b/examples/catsdogs-classification/project.clj
@@ -1,11 +1,11 @@
-(defproject mnist-classification "0.9.12-SNAPSHOT"
+(defproject catsdogs-classification "0.9.12-SNAPSHOT"
   :description "An example of using experiment/classification on mnist."
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/experiment "0.9.12-SNAPSHOT"]
                  [org.clojure/tools.cli "0.3.5"]
 
                  ; to manipulate images
-                 [thinktopic/think.image "0.4.8"]
+                 [thinktopic/think.image "0.4.11-SNAPSHOT"]
                  ; [net.mikera/imagez "0.12.0"]
                  ;;If you need cuda 8...
                  [org.bytedeco.javacpp-presets/cuda "8.0-1.2"]
@@ -13,8 +13,6 @@
                  ;;[org.bytedeco.javacpp-presets/cuda "7.5-1.2"]
                  ]
 
-  ; :main mnist-classification.main
-  ; :aot [mnist-classification.main]
   :jvm-opts ["-Xmx2000m"]
   :uberjar-name "classify-example.jar"
 

--- a/examples/catsdogs-classification/src/catsdogs/training.clj
+++ b/examples/catsdogs-classification/src/catsdogs/training.clj
@@ -1,5 +1,5 @@
 (ns catsdogs.training
-  (require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]))
 
 ;;;
 ; SETUP: PARAMETERS
@@ -85,11 +85,12 @@
   ; this will run forever
   ; exit the process when the value is high enough
   (require '[cortex.experiment.classification :as classification])
-  (classification/perform-experiment
-    (initial-description image-size image-size num-classes)
-                                   train-ds
-                                   test-ds
-                                   observation->image
-                                   class-mapping
-                                   {})
-)
+  (let [listener (classification/create-listener observation->image
+                                                 class-mapping
+                                                 {})]
+    (classification/perform-experiment
+     (initial-description image-size image-size num-classes)
+     train-ds
+     test-ds
+     listener))
+  )

--- a/examples/docker-example/project.clj
+++ b/examples/docker-example/project.clj
@@ -1,6 +1,6 @@
 (defproject docker "0.9.12-SNAPSHOT"
   :description "A simple example of how to run a cortex application in a docker container."
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/cortex "0.9.12-SNAPSHOT"]
                  [org.bytedeco.javacpp-presets/cuda "8.0-1.2"]]
 

--- a/examples/mnist-classification/project.clj
+++ b/examples/mnist-classification/project.clj
@@ -1,9 +1,9 @@
 (defproject mnist-classification "0.9.12-SNAPSHOT"
   :description "An example of using experiment/classification on mnist."
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/experiment "0.9.12-SNAPSHOT"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [thinktopic/think.image "0.4.8"]
+                 [thinktopic/think.image "0.4.11-SNAPSHOT"]
                  ;;If you need cuda 8...
                  [org.bytedeco.javacpp-presets/cuda "8.0-1.2"]
                  ;;If you need cuda 7.5...

--- a/examples/mnist-classification/src/mnist_classification/core.clj
+++ b/examples/mnist-classification/src/mnist_classification/core.clj
@@ -140,9 +140,9 @@
          listener (if-let [file-path (:tensorboard-output argmap)]
                     (classification/create-tensorboard-listener 
                           {:file-path file-path})
-                      (classification/create-listener mnist-observation->image
-                                                  class-mapping
-                                                  argmap))]
+                    (classification/create-listener mnist-observation->image
+                                                    class-mapping
+                                                    argmap))]
      (classification/perform-experiment
       (initial-description image-size image-size num-classes)
       train-ds test-ds listener))))

--- a/examples/optimise/project.clj
+++ b/examples/optimise/project.clj
@@ -7,7 +7,7 @@
                :tags [:clojure :optimization :gradient-descent
                       :machine-learning :exploratory :mathematica
                       :repl]}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/cortex "0.9.12-SNAPSHOT"]
                  [net.mikera/vectorz-clj "0.45.0"]
                  [net.mikera/core.matrix "0.57.0"]

--- a/examples/visualization/project.clj
+++ b/examples/visualization/project.clj
@@ -3,7 +3,7 @@
   :url "http://cortex.thinktopic.com"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/think.tsne "0.1.1"]
                  [incanter/incanter-core "1.5.7"]
                  [incanter/incanter-charts "1.5.7"]

--- a/experiment/project.clj
+++ b/experiment/project.clj
@@ -1,6 +1,6 @@
 (defproject thinktopic/experiment "0.9.12-SNAPSHOT"
   :description "A higher-level library for performing experiments with cortex."
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/cortex "0.9.12-SNAPSHOT"]
                  [thinktopic/think.image "0.4.10"]
                  [org.shark8me/tfevent-sink "0.1.3"]
@@ -10,7 +10,7 @@
                  [thinktopic/think.gate "0.1.3"]
                  ;;This had better precisely match the version of figwheel that think.gate uses
                  ;;Tried with 1.9.XXX and had odd unexplainable failures.
-                 [org.clojure/clojurescript "1.8.51"]]
+                 [org.clojure/clojurescript "1.9.671"]]
 
   :plugins [[lein-cljsbuild "1.1.5"]
             [lein-garden "0.3.0"]]

--- a/importers/caffe/project.clj
+++ b/importers/caffe/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/thinktopic/cortex"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/hdf5 "0.1.3"]
                  [thinktopic/cortex "0.9.12-SNAPSHOT"]
                  [instaparse "1.4.3"]

--- a/importers/keras/project.clj
+++ b/importers/keras/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/thinktopic/cortex"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/hdf5 "0.1.3"]
                  [thinktopic/cortex "0.9.12-SNAPSHOT"]
                  [cheshire "5.6.3"]]

--- a/importers/model-upgrader/project.clj
+++ b/importers/model-upgrader/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [com.taoensso/nippy "2.13.0"]
                  [thinktopic/think.datatype "0.3.10"]
                  ;;Last version of vectorz library that we saved to the file.

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/thinktopic/cortex"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [thinktopic/think.datatype "0.3.11"]
                  [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
                  [com.taoensso/nippy "2.13.0"]


### PR DESCRIPTION
Updating to clojure 1.9

Requires a small update in think.image https://github.com/thinktopic/think.image/pull/10 - once the pull request is merged, the version numbers in this pull request can be updated.

Tested all the examples and they seem to work fine.

The only area that I didn't test, because I don't have all the local deps, are the importers. They would still need to be checked out