### PR TITLE
 enable passing arguments to perform-experiment API

### DIFF
--- a/experiment/src/cortex/experiment/classification.clj
+++ b/experiment/src/cortex/experiment/classification.clj
@@ -200,13 +200,12 @@
 (defn- train-forever
   "Train forever. This function never returns."
   [initial-description train-ds test-ds
-   {:keys [batch-size force-gpu? eval-fn] :or {batch-size 128}}]
+   {:keys [batch-size force-gpu? eval-fn] :or {batch-size 128}
+    :as train-args}]
   (let [network (network/linear-network initial-description)]
-    (experiment-train/train-n network
-                              train-ds test-ds
-                              :test-fn eval-fn
-                              :batch-size batch-size
-                              :force-gpu? force-gpu?)))
+    (apply (partial (experiment-train/train-n network
+                                              train-ds test-ds))
+           (-> train-args seq flatten))))
 
 (defn- display-dataset-and-model
   "Starts the web server that gives real-time training updates."
@@ -301,10 +300,18 @@
 
 (defn perform-experiment
   "Main entry point:
-    - initial-description: A cortex nerual net description to train.
+    - initial-description: A cortex neural net description to train.
     - train-ds: A dataset (sequence of maps) with keys `:data`, `:labels`, used for training.
     - test-ds: A dataset (sequence of maps) with keys `:data`, `:labels`, used for testing.
- " ([initial-description train-ds test-ds listener]
-   (let [eval-fn (listener initial-description train-ds test-ds)]
+    - listener: a function which takes 3 arguments: initial-description, train-ds and test-ds
+              and returns a function that is executed per epoch. It could be used
+              to evaluate status of training (e.g. for early stopping) or to save the network.
+    - train-args: a map of optional arguments such as a force-gpu?. See cortex.experiment.train/train-n for the full list of arguments
+  "
+  ([initial-description train-ds test-ds listener]
+   (perform-experiment initial-description train-ds test-ds listener {}))
+  ([initial-description train-ds test-ds listener train-args]
+   (let [test-fn (listener initial-description train-ds test-ds)]
      (train-forever initial-description train-ds test-ds
-                     {:eval-fn eval-fn}))))
+                    {:test-fn test-fn}
+                    train-args))))

--- a/experiment/src/cortex/experiment/classification.clj
+++ b/experiment/src/cortex/experiment/classification.clj
@@ -200,11 +200,10 @@
 (defn- train-forever
   "Train forever. This function never returns."
   [initial-description train-ds test-ds
-   {:keys [batch-size force-gpu? eval-fn] :or {batch-size 128}
-    :as train-args}]
+   train-args]
   (let [network (network/linear-network initial-description)]
-    (apply (partial (experiment-train/train-n network
-                                              train-ds test-ds))
+    (apply (partial experiment-train/train-n network
+                    train-ds test-ds)
            (-> train-args seq flatten))))
 
 (defn- display-dataset-and-model
@@ -313,5 +312,4 @@
   ([initial-description train-ds test-ds listener train-args]
    (let [test-fn (listener initial-description train-ds test-ds)]
      (train-forever initial-description train-ds test-ds
-                    {:test-fn test-fn}
-                    train-args))))
+                    (assoc train-args :test-fn test-fn)))))

--- a/experiment/test/cortex/experiment/tensorboard_test.clj
+++ b/experiment/test/cortex/experiment/tensorboard_test.clj
@@ -155,7 +155,7 @@
                                        {:epoch-count epoch-count})))
 
 (deftest test-perform-experiment
-  (let [train-fn (get-trainer train-and-eval)
+  (let [train-fn (get-trainer perform-experiment-eval)
         log-path "/tmp/tflogs/"
         pathname "linear-bn"]
     (mapv train-fn [linear-with-batch-norm]

--- a/experiment/test/cortex/experiment/tensorboard_test.clj
+++ b/experiment/test/cortex/experiment/tensorboard_test.clj
@@ -7,9 +7,11 @@
             [cortex.nn.execute :as execute]
             [cortex.experiment.train :as train]
             [cortex.nn.network :as network]
+            [cortex.experiment.classification :as classification]
             [clojure.core.async :as async :refer [>! <! <!! >!! chan close! go alts!]]
             [cortex.metrics :as met]
-            [cortex.experiment.logistic-test :as lt]))
+            [cortex.experiment.logistic-test :as lt])
+  (:import [java.nio.file Files]))
 
 ;; "Default" dataset taken from: https://cran.r-project.org/web/packages/ISLR/index.html
 ;; Distributed under the GPL-2 LICENSE
@@ -110,7 +112,7 @@
 
 (defn- train-and-eval
   [train-ds test-ds network-description log-file]
-  (let [epoch-count 20
+  (let [epoch-count 2
         metrics-chan (chan)
         event-writer-chan (start-tensorboard-broadcast log-file metrics-chan epoch-count)
         _ (train/train-n network-description train-ds test-ds
@@ -119,13 +121,20 @@
     ;;wait for the listener to finish reading epoch-count events
     (<!! event-writer-chan)))
 
-(deftest test-listener
+(defn get-trainer
+  "given a training function, returns a partial function that trains on
+  a 90-10 split of the default dataset"
+  [trainer-fn]
   (let [ds (shuffle (default-dataset))
-          log-path "/tmp/tflogs/"
-          ds-count (count ds)
-          train-ds (take (int (* 0.9 ds-count)) ds)
-          test-ds (drop (int (* 0.9 ds-count)) ds)
-          train-fn (partial train-and-eval train-ds test-ds)]
+        ds-count (count ds)
+        train-ds (take (int (* 0.9 ds-count)) ds)
+        test-ds (drop (int (* 0.9 ds-count)) ds)
+        train-fn (partial trainer-fn train-ds test-ds)]
+    train-fn))
+
+(deftest test-listener
+  (let [train-fn (get-trainer train-and-eval)
+        log-path "/tmp/tflogs/"]
       (mapv train-fn [linear-with-batch-norm
                       linear-without-batch-norm relu-with-batch-norm
                       tanh-with-batch-norm]
@@ -135,3 +144,23 @@
                   ["linear"
                    "linear_nobatchnorm" "relu" "tanh"]))
       (is (.exists (io/file (str log-path "/linear/tfevents.linear.out"))))))
+
+(defn- perform-experiment-eval
+  [train-ds test-ds network-description log-file]
+  (let [epoch-count 2
+        listener (classification/create-tensorboard-listener 
+                       {:file-path log-file})]
+    (classification/perform-experiment network-description train-ds test-ds
+                                       listener
+                                       {:epoch-count epoch-count})))
+
+(deftest test-perform-experiment
+  (let [train-fn (get-trainer train-and-eval)
+        log-path "/tmp/tflogs/"
+        pathname "linear-bn"]
+    (mapv train-fn [linear-with-batch-norm]
+          (mapv #(let [path (str log-path % "/tfevents." % ".out")]
+                   (io/make-parents path)
+                   path)
+                [pathname]))
+    (is (.exists (io/file (str log-path "/linear-bn/tfevents." pathname ".out"))))))


### PR DESCRIPTION
The perform-experiment API calls the train-forever method, but did not optional allow arguments (such as force-gpu?) to be passed to the train-forever method. 
I changed the API to take a (optional) map containing arguments which is then passed to the train-forever method.  

I also added a test that calls the perform-experiment API with optional arguments.