### PR TITLE
rename var xor -> xor-dataset

### DIFF
--- a/examples/xor-mlp/src/xor_mlp/core.clj
+++ b/examples/xor-mlp/src/xor_mlp/core.clj
@@ -24,6 +24,6 @@
                                :epoch-count 3000
                                :simple-loss-print? true)]
     (println "\nXOR results before training:")
-    (clojure.pprint/pprint (execute/run nn xor))
+    (clojure.pprint/pprint (execute/run nn xor-dataset))
     (println "\nXOR results after training:")
-    (clojure.pprint/pprint (execute/run trained xor))))
+    (clojure.pprint/pprint (execute/run trained xor-dataset))))


### PR DESCRIPTION
Noticed these calls to `execute/run` were referencing unbound `xor` instead of `xor-dataset`.

```
xor-mlp.core=> (train-xor)

IllegalStateException Attempting to call unbound fn: #'xor-mlp.core/train-xor  clojure.lang.Var$Unbound.throwArity (Var.java:43)
```