### PR TITLE
Upgrading to a minimized and slightly optimized datatype library.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [thinktopic/think.datatype "0.3.12"]
+                 [thinktopic/think.datatype "0.3.15"]
                  [com.github.fommil.netlib/all "1.1.2" :extension "pom"]
                  [com.taoensso/nippy "2.13.0"]
                  ;; Change the following dep to depend on different versions of CUDA

--- a/src/cortex/compute/array_view_math.clj
+++ b/src/cortex/compute/array_view_math.clj
@@ -1,7 +1,7 @@
 (ns cortex.compute.array-view-math
   (:require [cortex.compute.math-util :refer :all]
             [clojure.core.matrix.macros :refer [c-for]]
-            [think.datatype.core :refer [v-aget-rem v-aset-rem v-aget v-aset] :as dtype]
+            [think.datatype.core :refer [v-aget v-aset] :as dtype]
             [think.resource.core :as resource])
   (:import [com.github.fommil.netlib BLAS]
            [java.util Random]
@@ -38,11 +38,15 @@
          y-view# (ArrayView/toView ~y)
          x-view# (ArrayView/toView ~x)
          res-view# (ArrayView/toView ~result)
+         res-len# (.length res-view#)
+         x-len# (.length x-view#)
+         y-len# (.length y-view#)
          num-elems# (Math/max (.length x-view#) (.length y-view#))]
      (c-for [idx# 0 (< idx# num-elems#) (inc idx#)]
-            (v-aset-rem res-view# idx#
-                  (+ (* alpha# (v-aget-rem x-view# idx#))
-                     (* beta# (v-aget-rem y-view# idx#)))))))
+            (v-aset res-view# (rem idx#
+                                   res-len#)
+                  (+ (* alpha# (v-aget x-view# (rem idx# x-len#)))
+                     (* beta# (v-aget y-view# (rem idx# y-len#))))))))
 
 
 (defmacro mul-rows-impl

--- a/src/cortex/compute/cuda/backend.clj
+++ b/src/cortex/compute/cuda/backend.clj
@@ -9,6 +9,7 @@
             [cortex.compute.cpu.backend :as cpu-backend]
             [cortex.optimize :as opt]
             [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [think.resource.core :as resource]
             [cortex.compute.cuda.driver :refer [->ptr value->ptr] :as cuda-drv]
             [cortex.compute.cuda.tensor-math])
@@ -47,7 +48,7 @@
   (get-driver
     [backend]
     (drv/get-driver (drv/get-device backend)))
-  dtype/PDatatype
+  dtype-base/PDatatype
   (get-datatype
     [backend]
     (get backend :datatype)))

--- a/src/cortex/compute/cuda/driver.clj
+++ b/src/cortex/compute/cuda/driver.clj
@@ -1,6 +1,7 @@
 (ns cortex.compute.cuda.driver
   (:require [cortex.compute.driver :as drv]
             [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [think.datatype.marshal :as marshal]
             [clojure.java.io :as io]
             [think.resource.core :as resource]
@@ -358,7 +359,7 @@ set this device before.  Set device must be called before any other cuda functio
    "_d"])
 
 (def datatype->suffixes-map
-  (into {} (map vec (partition 2 (interleave dtype/datatypes suffixes)))))
+  (into {} (map vec (partition 2 (interleave dtype-base/datatypes suffixes)))))
 
 (defn fn-name-datatype->fn-name
   [fn-name datatype]
@@ -383,9 +384,9 @@ set this device before.  Set device must be called before any other cuda functio
 
 (defn load-all-datatype-function
   ([module-name fn-name]
-   (load-multiple-datatype-function module-name fn-name dtype/datatypes))
+   (load-multiple-datatype-function module-name fn-name dtype-base/datatypes))
   ([fn-name]
-   (load-multiple-datatype-function fn-name dtype/datatypes)))
+   (load-multiple-datatype-function fn-name dtype-base/datatypes)))
 
 (defn load-float-double-function
   ([module-name fn-name]
@@ -400,8 +401,8 @@ set this device before.  Set device must be called before any other cuda functio
     (let [module (with-open [io-stream (io/input-stream
                                         (io/resource (format "%s.fatbin" fn-name)))]
                    (load-module io-stream))]
-      (->> (for [lhs-dtype dtype/datatypes
-                 rhs-dtype dtype/datatypes]
+      (->> (for [lhs-dtype dtype-base/datatypes
+                 rhs-dtype dtype-base/datatypes]
              (let [fn-name (format "%s%s%s"
                                    fn-name
                                    (get datatype->suffixes-map lhs-dtype)
@@ -477,9 +478,9 @@ set this device before.  Set device must be called before any other cuda functio
   (let [lhs-start (.address ^Pointer (->ptr lhs))
         rhs-start (.address ^Pointer (->ptr rhs))
         lhs-byte-count (* (long (m/ecount lhs))
-                          (dtype/datatype->byte-size (dtype/get-datatype lhs)))
+                          (dtype-base/datatype->byte-size (dtype/get-datatype lhs)))
         rhs-byte-count (* (long (m/ecount rhs))
-                          (dtype/datatype->byte-size (dtype/get-datatype rhs)))]
+                          (dtype-base/datatype->byte-size (dtype/get-datatype rhs)))]
     (or (in-range? lhs-start rhs-start rhs-byte-count)
         (in-range? rhs-start lhs-start lhs-byte-count))))
 
@@ -492,14 +493,14 @@ set this device before.  Set device must be called before any other cuda functio
     (cuda-library-debug-print "Free: " (.address ptr))
     (cuda-call (cuda/cudaFree ptr)))
   mp/PElementCount
-  (element-count [item] (quot size (dtype/datatype->byte-size
+  (element-count [item] (quot size (dtype-base/datatype->byte-size
                                     (dtype/get-datatype ptr))))
-  dtype/PDatatype
+  dtype-base/PDatatype
   (get-datatype [item] (dtype/get-datatype ptr))
   drv/PBuffer
   (sub-buffer-impl [this offset length]
     (->DevicePointer
-     (* (dtype/datatype->byte-size (dtype/get-datatype ptr))
+     (* (dtype-base/datatype->byte-size (dtype/get-datatype ptr))
         (long length))
      (drv/sub-buffer-impl ptr offset length)))
   (alias? [lhs-dev-buffer rhs-dev-buffer]
@@ -516,26 +517,26 @@ set this device before.  Set device must be called before any other cuda functio
     (cuda-library-debug-print "FreeHost: " (.address ptr))
     (check-cuda-error (cuda/cudaFreeHost ptr)))
   mp/PElementCount
-  (element-count [_] (quot size (dtype/datatype->byte-size (dtype/get-datatype ptr))))
-  dtype/PDatatype
+  (element-count [_] (quot size (dtype-base/datatype->byte-size (dtype/get-datatype ptr))))
+  dtype-base/PDatatype
   (get-datatype [_] (dtype/get-datatype ptr))
 
-  dtype/PAccess
-  (set-value! [_ offset value] (dtype/set-value! ptr offset value))
+  dtype-base/PAccess
+  (set-value! [_ offset value] (dtype-base/set-value! ptr offset value))
   (set-constant! [_ offset value elem-count]
-    (dtype/set-constant! ptr offset value elem-count))
-  (get-value [_ offset] (dtype/get-value ptr offset))
+    (dtype-base/set-constant! ptr offset value elem-count))
+  (get-value [_ offset] (dtype-base/get-value ptr offset))
   marshal/PTypeToCopyToFn
   (get-copy-to-fn [_ dest-offset]
     (marshal/get-copy-to-fn ptr dest-offset))
-  dtype/PCopyQueryIndirect
-  (get-indirect-copy-fn [_ dest-offset]
+  dtype-base/PCopyQuery
+  (get-copy-fn [_ dest-offset]
     (marshal/get-copy-to-fn ptr dest-offset))
 
   drv/PBuffer
   (sub-buffer-impl [this offset length]
     (->PageLockedPointer
-     (* (dtype/datatype->byte-size (dtype/get-datatype ptr))
+     (* (dtype-base/datatype->byte-size (dtype/get-datatype ptr))
         (long length))
      (drv/sub-buffer-impl ptr offset length))))
 
@@ -563,7 +564,7 @@ set this device before.  Set device must be called before any other cuda functio
 
 (defn- alloc-page-locked-memory
   [driver ^long elem-count elem-type]
-  (let [size (* (dtype/datatype->byte-size elem-type) elem-count)
+  (let [size (* (dtype-base/datatype->byte-size elem-type) elem-count)
         retval (jcpp-dtype/make-empty-pointer-of-type elem-type)]
     (check-cuda-error (cuda/cudaMallocHost retval size))
     (cuda-library-debug-print "MallocHost: " (.address retval))
@@ -891,7 +892,7 @@ relies only on blockDim.x block.x and thread.x"
   (allocate-device-buffer-impl [impl ^long elem-count elem-type]
     (drv/unsafe-with-compute-device
      impl
-     (let [size (* (dtype/datatype->byte-size elem-type) elem-count)
+     (let [size (* (dtype-base/datatype->byte-size elem-type) elem-count)
            retval (jcpp-dtype/make-empty-pointer-of-type elem-type)]
        (cuda-call (cuda/cudaMalloc retval size))
        (cuda-library-debug-print "Malloc: " (.address retval))
@@ -930,7 +931,7 @@ relies only on blockDim.x block.x and thread.x"
     (cuda-call
      (cuda/cudaMemcpyAsync (->ptr dest-buffer dest-offset)
                            (->ptr src-buffer src-offset)
-                           (* elem-count (dtype/datatype->byte-size
+                           (* elem-count (dtype-base/datatype->byte-size
                                           (dtype/get-datatype dest-buffer)))
                            ^long copy-type (.stream stream)))))
 
@@ -1201,7 +1202,7 @@ relies only on blockDim.x block.x and thread.x"
      (let [buf-dtype (dtype/get-datatype device-buffer)
            cuda-stream (.stream stream)]
        (if (= 0.0 (double elem-val))
-         (let [buf-dtype-size (dtype/datatype->byte-size buf-dtype)
+         (let [buf-dtype-size (dtype-base/datatype->byte-size buf-dtype)
                bytes (* (long elem-count) buf-dtype-size)
                offset (* (long device-offset) buf-dtype-size)]
            (cuda/cudaMemsetAsync (->ptr device-buffer offset) (int 0) (long bytes) cuda-stream))
@@ -1482,7 +1483,7 @@ relies only on blockDim.x block.x and thread.x"
 
 
 (extend-type cudnn$cudnnTensorStruct
-  dtype/PDatatype
+  dtype-base/PDatatype
   (get-datatype [tensor]
     (let [tensor-data (get-tensor tensor)
           tensor-dtype (:data-type tensor-data)]

--- a/src/cortex/compute/javacpp_datatype.clj
+++ b/src/cortex/compute/javacpp_datatype.clj
@@ -1,7 +1,7 @@
 (ns cortex.compute.javacpp-datatype
   (:require [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [think.datatype.marshal :as marshal]
-            [think.datatype.time-test :as time-test]
             [clojure.core.matrix.protocols :as mp])
   (:import [org.bytedeco.javacpp
             BytePointer IntPointer LongPointer DoublePointer
@@ -23,7 +23,7 @@
 (System/setProperty "org.bytedeco.javacpp.nopointergc" "true")
 
 
-(extend-protocol dtype/PDatatype
+(extend-protocol dtype-base/PDatatype
   BytePointer
   (get-datatype [ptr] :byte)
   ShortPointer
@@ -85,8 +85,8 @@ threadsafe while (.position ptr offset) is not."
     ;;code for dealing with position is incorrect.
     (.set ^Field address-field retval (+ addr
                                          (* (+ pos offset)
-                                            (dtype/datatype->byte-size
-                                             (dtype/get-datatype ptr)))))
+                                            (dtype-base/datatype->byte-size
+                                             (dtype-base/get-datatype ptr)))))
     retval))
 
 
@@ -127,11 +127,11 @@ threadsafe while (.position ptr offset) is not."
 
 
 (extend-type Pointer
-  dtype/PAccess
-  (set-value! [ptr ^long offset value] (dtype/set-value! (as-buffer ptr) offset value))
+  dtype-base/PAccess
+  (set-value! [ptr ^long offset value] (dtype-base/set-value! (as-buffer ptr) offset value))
   (set-constant! [ptr offset value elem-count]
-    (dtype/set-constant! (as-buffer ptr) offset value elem-count))
-  (get-value [ptr ^long offset] (dtype/get-value (as-buffer ptr) offset))
+    (dtype-base/set-constant! (as-buffer ptr) offset value elem-count))
+  (get-value [ptr ^long offset] (dtype-base/get-value (as-buffer ptr) offset))
 
   mp/PElementCount
   (element-count [ptr] (.capacity ptr)))
@@ -159,15 +159,6 @@ threadsafe while (.position ptr offset) is not."
   marshal/PTypeToCopyToFn
   (get-copy-to-fn [dest dest-offset]
     (marshal/get-copy-to-fn (as-buffer dest) dest-offset))
-  dtype/PCopyQueryIndirect
-  (get-indirect-copy-fn [dest dest-offset]
+  dtype-base/PCopyQuery
+  (get-copy-fn [dest dest-offset]
     (marshal/get-copy-to-fn dest dest-offset)))
-
-
-(defn float->double-ary-time-test
-  []
-  (let [n-elems 100000
-        src (make-pointer-of-type :float (range n-elems))
-        dest (double-array n-elems)]
-    (time-test/time-test
-     #(dtype/copy! src 0 dest 0 n-elems))))

--- a/src/cortex/compute/math.clj
+++ b/src/cortex/compute/math.clj
@@ -8,6 +8,7 @@
             [clojure.core.matrix.macros :refer [c-for]]
             [cortex.compute.driver :as drv]
             [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [think.resource.core :as resource]
             [cortex.tensor :as ct]
             [cortex.tensor.dimensions :as ct-dims]))
@@ -169,17 +170,6 @@ result[res-indexes[idx]] = alpha * x[x-indexes[idx]] + beta * y[y-indexes[idx]];
   (batch-size [item] (.batch-size item)))
 
 
-(defn make-java-array
-  "Given a datatype and a specific amount of data then produce an array.  If there is no fast path
-then an array of a given type is produced."
-  [datatype data]
-  (let [data (or (mp/as-double-array data)
-                 data)]
-    (if (dtype/is-primitive-array? data)
-      data
-      (dtype/make-array-of-type datatype (vec (m/eseq data))))))
-
-
 (defprotocol PGetDeviceBuffer
   (device-buffer [item]
     "Given a generic object product the device buffer backing data store for the object."))
@@ -193,7 +183,7 @@ then an array of a given type is produced."
 (defrecord DeviceArray [device-buffer ^Tensor tensor])
 
 (extend-type DeviceArray
-  dtype/PDatatype
+  dtype-base/PDatatype
   (get-datatype [ary] (dtype/get-datatype (.device-buffer ary)))
   mp/PElementCount
   (element-count [ary] (mp/element-count (.tensor ary)))
@@ -204,7 +194,7 @@ then an array of a given type is produced."
   (batch-size [ary] (batch-size (.tensor ary)))
   PGetDeviceBuffer
   (device-buffer [ary] (.device-buffer ary))
-  dtype/PView
+  dtype-base/PView
   (->view-impl [ary offset length]
     (dtype/->view (.device-buffer ary) offset length)))
 

--- a/src/cortex/compute/verify/driver.clj
+++ b/src/cortex/compute/verify/driver.clj
@@ -3,6 +3,7 @@
             [cortex.compute.driver :as drv]
             [cortex.compute.math :as math]
             [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [clojure.core.matrix :as m]))
 
 
@@ -18,7 +19,7 @@
           input-data (dtype/make-array-of-type datatype (range 10))
           output-data (dtype/make-array-of-type datatype 10)]
       (dtype/copy! input-data 0 buf-a 0 10)
-      (dtype/set-value! buf-a 0 100.0)
+      (dtype-base/set-value! buf-a 0 100.0)
       (dtype/copy! buf-a 0 output-data 0 10)
       (drv/copy-host->device stream buf-a 0 buf-b 0 10)
       (drv/memset stream buf-b 5 20.0 5)

--- a/src/cortex/loss/center.clj
+++ b/src/cortex/loss/center.clj
@@ -27,8 +27,8 @@
           monotonic-indexes (math/device-buffer monotonic-indexes)
           beta (- 1.0 alpha)]
       ;;First distribute centers according to labels
-      (drv/indexed-copy stream centers label-indexes
-                        batch-centers monotonic-indexes n-elems)
+      (drv/indexed-copy stream (math/device-buffer centers) (math/device-buffer label-indexes)
+                        (math/device-buffer batch-centers) (math/device-buffer monotonic-indexes) n-elems)
       ;;gradient = feature - center
       (math/subtract stream 1.0 output-buffer 1.0 batch-centers output-gradient)
       ;;copy features to batch-centers to start to calculate new centers

--- a/src/cortex/optimize/adam.clj
+++ b/src/cortex/optimize/adam.clj
@@ -8,7 +8,7 @@
    [cortex.compute.cpu.driver :as cpu-drv]
    ;[cortex.compute.cuda.driver :as cuda-drv]
    [cortex.util :as util]
-   [think.datatype.core :refer [v-aget-rem v-aset-rem v-aget v-aset] :as dtype]
+   [think.datatype.core :refer [v-aget v-aset] :as dtype]
    [think.datatype.marshal :as marshal]
    [think.parallel.core :as parallel]
    [cortex.graph :as graph]

--- a/src/cortex/tensor.clj
+++ b/src/cortex/tensor.clj
@@ -45,6 +45,7 @@ For indirect operations element count is num-indexes * num-columns.  After that 
   larger."
   (:require [cortex.compute.driver :as compute-drv]
             [think.datatype.core :as dtype]
+            [think.datatype.base :as dtype-base]
             [clojure.core.matrix.protocols :as mp]
             [mikera.vectorz.matrix-api]
             [cortex.graph :as graph]
@@ -181,7 +182,7 @@ that rerequires the items to have the same element count."
 
 ;;Tensors are a tuple of device (driver for now) dimensions and index system and buffer.
 (defrecord Tensor [device dimensions buffer]
-  dtype/PDatatype
+  dtype-base/PDatatype
   (get-datatype [tensor] (dtype/get-datatype (:buffer tensor)))
   compute-drv/PDeviceProvider
   (get-device [tensor] device)

--- a/src/cortex/verify/nn/train.clj
+++ b/src/cortex/verify/nn/train.clj
@@ -28,7 +28,6 @@
    (layers/batch-normalization :mode :spatial)
    (layers/dropout 0.9)
    (layers/relu)
-   (layers/local-response-normalization)
    (layers/convolutional 5 0 1 50)
    (layers/max-pooling 2 0 2)
    (layers/batch-normalization :l1-regularization 1e-4)

--- a/test/clj/cortex/compute/compute_loss_test.clj
+++ b/test/clj/cortex/compute/compute_loss_test.clj
@@ -9,5 +9,5 @@
 
 (use-fixtures :each test-utils/test-wrapper)
 
-(def-double-float-test center-loss
+(deftest center-loss
   (verify-loss/center-loss (cpu.backend/backend :datatype test-utils/*datatype*)))

--- a/test/clj/cortex/compute/cpu_driver_test.clj
+++ b/test/clj/cortex/compute/cpu_driver_test.clj
@@ -15,7 +15,7 @@
   []
   (cpu/driver))
 
-(def-all-dtype-test simple-stream
+(def-double-float-test simple-stream
   (verify-driver/simple-stream (driver) test-utils/*datatype*))
 
 (def-double-float-test indexed-copy

--- a/test/clj/cortex/compute/nn/gradient_test.clj
+++ b/test/clj/cortex/compute/nn/gradient_test.clj
@@ -18,8 +18,8 @@
 (deftest batch-normalization
   (gradient/batch-normalization-gradient (create-context)))
 
-(deftest local-response-normalization-gradient
-  (gradient/lrn-gradient (create-context)))
+;; (deftest local-response-normalization-gradient
+;;   (gradient/lrn-gradient (create-context)))
 
 (deftest prelu-gradient
   (gradient/prelu-gradient (create-context)))

--- a/test/clj/cortex/compute/nn/layers_test.clj
+++ b/test/clj/cortex/compute/nn/layers_test.clj
@@ -73,8 +73,8 @@
 (def-double-float-test batch-normalization
   (verify-layers/batch-normalization (create-context)))
 
-(def-double-float-test local-response-normalization-forward
-  (verify-layers/lrn-forward (create-context)))
+;; (def-double-float-test local-response-normalization-forward
+;;   (verify-layers/lrn-forward (create-context)))
 
 (def-double-float-test prelu
   (verify-layers/prelu (create-context)))


### PR DESCRIPTION
Working back towards supporting clojurescript.  Also, however, the datatype library needed a major simplification pass.

Dropped CPU support for LRN layers.  This is better done with a convolution layer with kernel width,height of 1 and same number of kernels and input channels.

May attempt to re-engineer the LRN layer support using tensors later.  The GPU version still works and the tests are all still there just the cpu side of things is commented out.