### PR TITLE
fix keyword typo in multiplicative-dropout function in layers.clj

### DIFF
--- a/src/cortex/nn/layers.clj
+++ b/src/cortex/nn/layers.clj
@@ -289,7 +289,7 @@ If the input contains no channels then you get a scale factor per input paramete
      (assert (:variance args))
      [(assoc args
              :type :dropout
-             :ditribution :gaussian)]))
+             :distribution :gaussian)]))
   ([variance & args]
    [(merge-args
      {:type :dropout :distribution :gaussian :variance variance}


### PR DESCRIPTION
I found a typo in the multiplicative-dropout function where it would create a
map with :ditribution as the keyword rather than the correct :distribution.

I attempted to re-run all the cpu based unit tests and found no change in the
results. Unfortunately I don't have a cuda gpu capable of running the rest of
the tests.
