### PR TITLE
Support for train and test loss metrics via the experiment API

### DIFF
--- a/experiment/project.clj
+++ b/experiment/project.clj
@@ -4,7 +4,7 @@
                  [org.clojure/clojurescript "1.9.854"]
                  [thinktopic/cortex "0.9.23-SNAPSHOT"]
                  [thinktopic/think.image "0.4.16"]
-                 [org.shark8me/tfevent-sink "0.1.3"]
+                 [org.shark8me/tfevent-sink "0.1.4"]
                  ;;Default way of displaying anything is a web page.
                  ;;Because if you want to train on aws (which you should)
                  ;;you need to get simple servers up and running easily.


### PR DESCRIPTION

* supports a train and test loss, available for the train-forever as well as for tensorboard listener
* tensorboard listener takes an additional argument metric-fn that could accepts actual and predicted labels. It can be used to calculate metrics such as f1 scores/precision/recall, both average and per-class.