### PR TITLE
Update brew cuda installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Install coreutils and cuda:
 
     $ brew install coreutils
     $ brew tap caskroom/drivers
-    $ brew cask install cuda
+    $ brew cask install nvidia-cuda
 
 Add CUDA Tool kit to bash profile
 


### PR DESCRIPTION
cuda in caskroom/driver has already [renamed to nvidia-cuda since Oct 22](https://github.com/caskroom/homebrew-drivers/commit/f56e9ab9b8e2865e7c5965d014bcaa06ed196f19#diff-f9032f896f3316d57d071c60b61fa9c6). This PR update the cuda installation instruction to keep it up to the change mentioned.

#252 