### PR TITLE
support for turning on gradient outputs in :compute-graph's :buffers…

### DIFF
--- a/experiment/src/cortex/experiment/train.clj
+++ b/experiment/src/cortex/experiment/train.clj
@@ -188,9 +188,11 @@
              force-gpu?
              simple-loss-print?
              test-fn
-             context]
+             context
+             save-gradients?]
       :or {batch-size 128
            network-filestem default-network-filestem
+           save-gradients? false
            reset-score false}}]
   (let [context (or context (execute/compute-context))]
     (execute/with-compute-context context
@@ -216,7 +218,8 @@
             train-fn #(execute/train %1 %2
                                      :batch-size batch-size
                                      :optimizer %3
-                                     :context context)
+                                     :context context
+                                     :save-gradients? save-gradients?)
             training-context {:batch-size batch-size :context context}
             test-fn  (or test-fn
                          ;;Normally if the loss goes down then this is the best network

--- a/src/cortex/nn/execute.clj
+++ b/src/cortex/nn/execute.clj
@@ -436,10 +436,12 @@ from the size of their result and the traversal information updated to take this
 (defn train
   "Train.  Returns a tuple of network and optimizer where both the network and optimizer's
   parameters are updated."
-  [network dataset & {:keys [batch-size context optimizer datatype batch-transfer-parallelism]
+  [network dataset & {:keys [batch-size context optimizer datatype batch-transfer-parallelism
+                             save-gradients?]
                       :or {batch-size 10
                            datatype :float
-                           batch-transfer-parallelism 2}}]
+                           batch-transfer-parallelism 2
+                           save-gradients? false}}]
   (let [context (or context (compute-context :datatype datatype))]
     (with-compute-context context
       (let [optimizer (or optimizer (adam/adam))
@@ -465,7 +467,9 @@ from the size of their result and the traversal information updated to take this
           ;;Ensure the network is finished before we upload more things.
           (drv/sync-streams (compute-binding/stream network) batch-stream)
           (print-time-info :train-end))
-        (compute-binding/save-to-network context network {:save-optimizer-parameters? true})))))
+        (compute-binding/save-to-network context network
+                                         {:save-gradients? save-gradients?
+                                          :save-optimizer-parameters? true})))))
 
 
 (defn run


### PR DESCRIPTION

* Although compute-binding/save-to-network method has support for adding the gradients to the :buffer map, the *classification/perform-experiment* or *train/train-n* has no way to turn it on (primarily for debugging).
* Enabled execute/train method to accept an optional save-gradients? argument, which can be passed to the compute-binding/save-to-network method